### PR TITLE
PDF in inline view and new tab

### DIFF
--- a/background.js
+++ b/background.js
@@ -137,6 +137,7 @@ chrome.extension.onMessage.addListener(function(request, sender, sendResponse) {
   return true //required for async sendResponse
 
 })
+ 
 
 //register hotkeys
 chrome.commands.onCommand.addListener(function(command) {

--- a/contentScripts/content_bildungsportal_viewPDFinBrowser.js
+++ b/contentScripts/content_bildungsportal_viewPDFinBrowser.js
@@ -1,24 +1,30 @@
-chrome.storage.local.get(['PDFViewerIsEnabled'], function (result) {
-    //if (result.PDFViewerIsEnabled) {
+chrome.storage.local.get(["pdfInNewTab"], function (result) {
+    if (result.pdfInNewTab) {
         //on load
         document.addEventListener("DOMNodeInserted", function (e) {
-           modifyPdfLinks()
-        })
+            modifyPdfLinks();
+        });
         //on document changes
-        window.addEventListener("load", function () {
-            modifyPdfLinks()
-        }, true)
-    //}
-})
+        window.addEventListener(
+            "load",
+            function () {
+                modifyPdfLinks();
+            },
+            true
+        );
+    }
+});
 
 function modifyPdfLinks() {
     //Modify js so that link is opened in new tab
-    let links = document.getElementsByTagName("a")
-    for (let idx=0;idx<links.length;idx++){
-        if(links[idx].href.includes(".pdf")){
-            links[idx].setAttribute("onclick", "window.open(this.href, '_blank'); return false;")
+    let links = document.getElementsByTagName("a");
+    for (let idx = 0; idx < links.length; idx++) {
+        if (links[idx].href.includes(".pdf")) {
+            links[idx].onclick = function (event) {
+                event.stopImmediatePropagation(); //prevents OPAL to load in the same tab
+                window.open(this.href, "_blank");
+                return false;
+            };
         }
     }
-    
 }
-

--- a/manifest.json
+++ b/manifest.json
@@ -3,11 +3,14 @@
   "version": "5.1.0.3",
   "description": "Das Produktivitäts-Tool für TU Dresden Studierende 🚀",
   "permissions": [
-    "storage", "system.cpu", "https://bildungsportal.sachsen.de/opal/*",
+    "storage", 
+    "system.cpu"    
+  ],
+  "optional_permissions": [
+    "*://*/",
     "webRequest",
     "webRequestBlocking"
   ],
-  "optional_permissions": [],
   "background": {
     "scripts": [
       "background.js"

--- a/settings.html
+++ b/settings.html
@@ -81,11 +81,12 @@
 </div>
 
     <!-- New Accordion section--> 
-    <button class="accordion" id="opal_modifications">Opal-Anpassungen</button>
+    <button class="accordion" id="opal_modifications">Opal Personalisieren und Verbessern</button>
     <div class="panel">
       <p>
+        Damit die Einstellungen wirksam werden, musst du Opal einmal aktualisieren.<br>
         <text class="grey-text">
-          Zum Anpassen der PDF-Anzeige ben&ouml;tigt TUfast m&ouml;glicherweise eine spezielle Berechtigung, dr&uuml;cke bitte auf
+          M&ouml;glicherweise braucht TUfast eine spezielle Berechtigung, dr&uuml;cke bitte auf
           "Erlauben" im folgenden
           Pop-Up.
         </text>
@@ -95,14 +96,14 @@
           <input type="checkbox" id="switch_pdf_inline">
           <span class="slider round"></span>
         </label>
-        &nbsp;&nbsp;PDF-Dokumente im Browser anzeigen anstatt herunterzuladen
+        &nbsp;&nbsp;PDF-Dokumente aus Opal direkt im Browser &ouml;fnnen, anstatt sie herunterzuladen
       </p>
       <p id="switch_pdf_newtab_block">
         <label class="switch">
           <input type="checkbox" id="switch_pdf_newtab">
           <span class="slider round"></span>
         </label>
-        &nbsp;&nbsp;PDF-Dokumente in neuem Tab &ouml;ffnen
+        &nbsp;&nbsp;PDF-Dokumente in neuem Tab &ouml;ffnen (empfohlen!)
       </p>
     </div>
 

--- a/settings.html
+++ b/settings.html
@@ -84,6 +84,13 @@
     <button class="accordion" id="opal_modifications">Opal-Anpassungen</button>
     <div class="panel">
       <p>
+        <text class="grey-text">
+          Zum Anpassen der PDF-Anzeige ben&ouml;tigt TUfast m&ouml;glicherweise eine spezielle Berechtigung, dr&uuml;cke bitte auf
+          "Erlauben" im folgenden
+          Pop-Up.
+        </text>
+      </p>
+      <p>
         <label class="switch">
           <input type="checkbox" id="switch_pdf_inline">
           <span class="slider round"></span>

--- a/settings.html
+++ b/settings.html
@@ -78,7 +78,27 @@
     </p> 
     <p>
     </p> 
-</div> 
+</div>
+
+    <!-- New Accordion section--> 
+    <button class="accordion" id="opal_modifications">Opal-Anpassungen</button>
+    <div class="panel">
+      <p>
+        <label class="switch">
+          <input type="checkbox" id="switch_pdf_inline">
+          <span class="slider round"></span>
+        </label>
+        &nbsp;&nbsp;PDF-Dokumente im Browser anzeigen anstatt herunterzuladen
+      </p>
+      <p id="switch_pdf_newtab_block">
+        <label class="switch">
+          <input type="checkbox" id="switch_pdf_newtab">
+          <span class="slider round"></span>
+        </label>
+        &nbsp;&nbsp;PDF-Dokumente in neuem Tab &ouml;ffnen
+      </p>
+    </div>
+
     <!-- New Accordion section--> 
     <button class="accordion" id="auto_login_settings">Automatisches Anmelden in Opal, Selma & Co.</button>
     <div class="panel">

--- a/settings.js
+++ b/settings.js
@@ -54,10 +54,32 @@ function fwdGoogleSearch() {
   })
 }
 
+function pdfInInline() {
+  chrome.storage.local.get(['pdfInInline'], function(result) {
+    chrome.storage.local.set({pdfInInline: !(result.pdfInInline)}, function() {})
+    chrome.runtime.sendMessage({cmd: 'toggle_pdf_inline_setting', enabled: !(result.pdfInInline)});
+  })
+}
+
+function pdfInNewTab() {
+  chrome.storage.local.get(['pdfInNewTab'], function(result) {
+    chrome.storage.local.set({pdfInNewTab: !(result.pdfInNewTab)}, function() {})
+  })
+}
+
+
 //set switches and other elements
 function displayEnabled() {
   chrome.storage.local.get(['fwdEnabled'], function(result) {
       this.document.getElementById('switch_fwd').checked = result.fwdEnabled
+  })
+
+  chrome.storage.local.get(['pdfInInline'], function(result) {
+    this.document.getElementById('switch_pdf_inline').checked = result.pdfInInline
+  })
+
+  chrome.storage.local.get(['pdfInNewTab'], function(result) {
+    this.document.getElementById('switch_pdf_newtab').checked = result.pdfInNewTab
   })
   /*chrome.storage.local.get(['dashboardDisplay'], function(result) {
     if(result.dashboardDisplay === "favoriten") {document.getElementById('fav').checked = true}
@@ -99,6 +121,8 @@ window.onload = function(){
     document.getElementById('save_data').onclick= saveUserData
     document.getElementById('delete_data').onclick= deleteUserData
     document.getElementById('switch_fwd').onclick = fwdGoogleSearch
+    document.getElementById('switch_pdf_inline').onclick = pdfInInline;
+    document.getElementById('switch_pdf_newtab').onclick = pdfInNewTab;
     document.getElementById('open_shortcut_settings').onclick = openKeyboardSettings
     document.getElementById('open_shortcut_settings1').onclick = openKeyboardSettings
     //document.getElementById('fav').onclick = dashboardCourseSelect

--- a/settings.js
+++ b/settings.js
@@ -54,20 +54,6 @@ function fwdGoogleSearch() {
   })
 }
 
-function pdfInInline() {
-  chrome.storage.local.get(['pdfInInline'], function(result) {
-    chrome.storage.local.set({pdfInInline: !(result.pdfInInline)}, function() {})
-    chrome.runtime.sendMessage({cmd: 'toggle_pdf_inline_setting', enabled: !(result.pdfInInline)});
-  })
-}
-
-function pdfInNewTab() {
-  chrome.storage.local.get(['pdfInNewTab'], function(result) {
-    chrome.storage.local.set({pdfInNewTab: !(result.pdfInNewTab)}, function() {})
-  })
-}
-
-
 //set switches and other elements
 function displayEnabled() {
   chrome.storage.local.get(['fwdEnabled'], function(result) {
@@ -76,6 +62,9 @@ function displayEnabled() {
 
   chrome.storage.local.get(['pdfInInline'], function(result) {
     this.document.getElementById('switch_pdf_inline').checked = result.pdfInInline
+    if(!result.pdfInInline){
+      document.getElementById("switch_pdf_newtab_block").style.visibility = "hidden";
+    }
   })
 
   chrome.storage.local.get(['pdfInNewTab'], function(result) {
@@ -121,8 +110,6 @@ window.onload = function(){
     document.getElementById('save_data').onclick= saveUserData
     document.getElementById('delete_data').onclick= deleteUserData
     document.getElementById('switch_fwd').onclick = fwdGoogleSearch
-    document.getElementById('switch_pdf_inline').onclick = pdfInInline;
-    document.getElementById('switch_pdf_newtab').onclick = pdfInNewTab;
     document.getElementById('open_shortcut_settings').onclick = openKeyboardSettings
     document.getElementById('open_shortcut_settings1').onclick = openKeyboardSettings
     //document.getElementById('fav').onclick = dashboardCourseSelect
@@ -140,6 +127,24 @@ window.onload = function(){
         }
       }
     });
+
+    document.getElementById("switch_pdf_inline").addEventListener("click", function () {
+            chrome.storage.local.set({ pdfInInline: this.checked }, function () {});
+            chrome.runtime.sendMessage({
+                cmd: "toggle_pdf_inline_setting",
+                enabled: this.checked,
+            });
+
+            document.getElementById("switch_pdf_newtab_block").style.visibility = this.checked ? "visible":"hidden";
+            if (!this.checked) {
+                //disable "pdf in new tab" setting since it doesn't make any sense without inline pdf
+                chrome.storage.local.set({ pdfInNewTab: false });
+            }
+        });
+
+    document.getElementById("switch_pdf_newtab").addEventListener("click", function () {
+            chrome.storage.local.set({ pdfInNewTab: this.checked }, function () {});
+        });
 
     //set all switches and elements
     displayEnabled()

--- a/settings.js
+++ b/settings.js
@@ -130,20 +130,32 @@ window.onload = function(){
 
     document.getElementById("switch_pdf_inline").addEventListener("click", function () {
             chrome.storage.local.set({ pdfInInline: this.checked }, function () {});
-            chrome.runtime.sendMessage({
-                cmd: "toggle_pdf_inline_setting",
-                enabled: this.checked,
-            });
+            document.getElementById("switch_pdf_newtab_block").style.visibility = this.checked ? "visible" : "hidden";
 
-            document.getElementById("switch_pdf_newtab_block").style.visibility = this.checked ? "visible":"hidden";
-            if (!this.checked) {
-                //disable "pdf in new tab" setting since it doesn't make any sense without inline pdf
-                chrome.storage.local.set({ pdfInNewTab: false });
+            if (this.checked) {
+              //request necessary permissions
+              chrome.permissions.request( { permissions: [ "webRequest", "webRequestBlocking" ], origins: [ "https://bildungsportal.sachsen.de/opal/*" ] },
+                function (granted) {
+                  if (granted) {
+                    chrome.runtime.sendMessage({ cmd: "toggle_pdf_inline_setting", enabled: true });
+                  } else {
+                    //permission granting failed :( -> revert checkbox settings
+                    chrome.storage.local.set({ pdfInInline: false });
+                    this.document.getElementById("switch_pdf_inline").checked = false;
+                    alert("TUfast braucht diese Berechtigung, um die PDFs im Browser anzeigen zu koennen");
+                  }
+                }
+              );
+            } else {
+              //disable "pdf in new tab" setting since it doesn't make any sense without inline pdf
+              chrome.storage.local.set({ pdfInNewTab: false });
+              document.getElementById("switch_pdf_newtab").checked = false;
+              chrome.runtime.sendMessage({ cmd: "toggle_pdf_inline_setting", enabled: false });
             }
         });
 
     document.getElementById("switch_pdf_newtab").addEventListener("click", function () {
-            chrome.storage.local.set({ pdfInNewTab: this.checked }, function () {});
+          chrome.storage.local.set({ pdfInNewTab: this.checked }, function () {});
         });
 
     //set all switches and elements


### PR DESCRIPTION
Hey Oliver,

ich habe mir die PDF-Anzeigethematik gerade mal angeschaut und das ganze lösen können.
In den Einstellungen gibt es jetzt zwei neue Optionen:
* `PDF-Dokumente im Browser anzeigen anstatt herunterzuladen` => beim Klick wird das PDF in dem im Browser integrierten Viewer angezeigt
* `PDF-Dokumente in neuem Tab öffnen` => die PDFs werden im neuen Tab geöffnet

Schau dir das gerne mal an und prüfe das auf Herz und Nieren! Ich saß gerade in einem ziemlich langweiligem Meeting und habe 'ne Nebenbeschäftigung gesucht :D

Komm bei Fragen oder Problemen gerne auf mich zu. Schönen Abend noch!