### PR TITLE
Hinzugefügte Funktionalität für das öffnen von PDF Buttons in einem neuen Tab

### DIFF
--- a/contentScripts/content_bildungsportal_viewPDFinBrowser.js
+++ b/contentScripts/content_bildungsportal_viewPDFinBrowser.js
@@ -9,6 +9,7 @@ chrome.storage.local.get(["pdfInNewTab"], function (result) {
             "load",
             function () {
                 modifyPdfLinks();
+                pdfButtonExternalReload();
             },
             true
         );
@@ -26,5 +27,34 @@ function modifyPdfLinks() {
                 return false;
             };
         }
+    }
+}
+
+function pdfButtonExternalReload() {
+    // Only run logic if URL path includes 'downloadering'.
+    // This is the page Opal requests on click on - let's call it - a 'document button'.
+    if (document.documentURI.includes('downloadering')) {
+        // The fiber code gets auto genereted, it seems kind of random.
+        // It doesn't identify a document, I saw two codes for the same PDF.
+
+        const fibercode_query = 'fibercode=';
+        const fibercode_pos = document.documentURI.lastIndexOf(fibercode_query);
+
+        const fibercode = document.documentURI.slice(fibercode_pos+fibercode_query.length);
+
+
+        // check if fibercode is already present to not reload the same page forever
+        chrome.storage.local.get(['fibercode'], (result) => {
+            if (result.fibercode === fibercode) {
+                // remove fibercode again after page opened in new tab (runs in new tab)
+                chrome.storage.local.set({fibercode: ''});
+            } else {
+                // set the fibercode if it doesn't exist in db (runs on button click)
+                chrome.storage.local.set({fibercode: fibercode}, () => {
+                    open(document.documentURI, '_blank');
+                    history.back();
+                });
+            }
+        });
     }
 }


### PR DESCRIPTION
Lösung des Issues #16. Nun werden auch PDFs in einem neuen Tab geöffnet, wenn sie hinter einem "PDF Button" liegen, so wie das zum Beispiel oft bei Belegen der Fall ist. Dasselbe gilt für das Herunterladen mittels Downloadbutton, solange nur eine einzelne PDF-Datei ausgewählt ist. Bei mehreren Dateien wird wie üblich ein Archiv heruntergeladen.

Der Code überprüft, ob er sich auf der Seite mit "/downloadering" befindet, auf diesem Pfad sendet der Server PDF-Dateien, die hinter diesen Buttons versteckt sind. Falls er sich auf dieser Seite befindet, lädt er die Seite in einem neuen Tab neu und geht auf der ursprünglichen Seite einen Schritt zurück, um den Eindruck zu erwecken, die Seite wäre nie verlassen worden.

Eine kleine Logik wird verwendet, um das unendliche Neulanden zu verhindern. Dafür wird kurzzeitig ein Eintrag im lokalen Speicher erstellt, der den "Fibercode" der Anfrage enthält. Dieser Code identifiziert das Dokument zum Zeitpunkt, an dem es angeschaut wird. Ist der Fibercode bereits gespeichert, weiß das Program, dass die Seite bereits in einem neuen Tab geöffnet wurde und löscht lediglich den Eintrag im lokalen Speicher für ein erneutes Öffnen.