### PR TITLE
Multiple accounts

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -362,6 +362,11 @@ chrome.runtime.onMessage.addListener((request, _sender, sendResponse) => {
       setUserData(request.userData, platform)
       break
     }
+    case 'check_user_data': {
+      const platform = request.platform || 'zih'
+      userDataExists(platform).then(response => sendResponse(response))
+      break
+    }
     case 'read_mail_owa':
       readMailOWA(request.NrUnreadMails)
       break

--- a/src/background.js
+++ b/src/background.js
@@ -362,7 +362,7 @@ chrome.runtime.onMessage.addListener((request, _sender, sendResponse) => {
     }
     case 'set_user_data': {
       const platform = request.platform || 'zih'
-      setUserData(request.userData, platform)
+      setUserData(request.userData, platform).then(() => sendResponse(true))
       break
     }
     case 'check_user_data': {

--- a/src/background.js
+++ b/src/background.js
@@ -261,7 +261,7 @@ function getAllChromeTabs () {
 // eslint-disable-next-line no-unused-vars
 async function loginDataExists (platform = 'zih') {
   const { user, pass } = await getUserData(platform)
-  return user && pass
+  return !!(user && pass)
 }
 
 // start OWA fetch funtion based on interval
@@ -622,7 +622,7 @@ async function userDataExists (platform) {
   if (typeof platform === 'string') {
     // Query for a specific platform
     const { user, pass } = await getUserData(platform)
-    return user && pass
+    return !!(user && pass)
   } else {
     // Query for any platform
     const data = await new Promise((resolve) => chrome.storage.local.get(['udata'], (data) => resolve(data.udata)))

--- a/src/background.js
+++ b/src/background.js
@@ -141,7 +141,7 @@ chrome.runtime.onInstalled.addListener(async (details) => {
             console.log('Upgrading encryption standard from level 1 to level 3...')
             // Promisified until usage of Manifest V3
             const userData = await new Promise((resolve) => chrome.storage.local.get(['asdf', 'fdsa'], resolve))
-            await setUserData({ asdf: atob(userData.asdf), fdsa: atob(userData.fdsa) }, 'zih')
+            await setUserData({ user: atob(userData.asdf), pass: atob(userData.fdsa) }, 'zih')
             break
           }
           case 2: {

--- a/src/background.js
+++ b/src/background.js
@@ -696,7 +696,7 @@ async function getUserDataLagacy () {
   const data = await new Promise((resolve) => chrome.storage.local.get(['Data'], (data) => resolve(data.Data)))
 
   // check if Data exists, else return
-  if (data === undefined) {
+  if (data === undefined || data === 'undefined') {
     return ({ asdf: undefined, fdsa: undefined })
   }
   let iv = data.slice(0, 32).match(/.{2}/g).map(byte => parseInt(byte, 16))

--- a/src/background.js
+++ b/src/background.js
@@ -515,7 +515,7 @@ async function saveClicks (counter) {
 }
 
 /// ///////////// FUNCTIONS FOR ENCRYPTION AND USERDATA HANDLING ////////////////
-// info: asdf = username | fdsa = password
+// info: user = username | pass = password
 
 // create hash from input-string (can also be json of course)
 // output hash is always of same length and is of type buffer

--- a/src/background.js
+++ b/src/background.js
@@ -353,12 +353,15 @@ chrome.runtime.onMessage.addListener((request, _sender, sendResponse) => {
       saveClicks(request.click_count)
       break
     case 'get_user_data': {
-      getUserData().then(userData => sendResponse(userData))
+      const platform = request.platform || 'zih'
+      getUserData(platform).then(userData => sendResponse(userData))
       break
     }
-    case 'set_user_data':
-      setUserData(request.userData)
+    case 'set_user_data': {
+      const platform = request.platform || 'zih'
+      setUserData(request.userData, platform)
       break
+    }
     case 'read_mail_owa':
       readMailOWA(request.NrUnreadMails)
       break
@@ -562,7 +565,7 @@ async function getKeyBuffer () {
 // user data is encrypted using the crpyto-js library (aes-cbc). The encryption key is created from pc-information with system.cpu
 // a lot of encoding and transforming needs to be done, in order to provide all values in the right format.
 async function setUserData (userData, platform = 'zih') {
-  if (!userData || !userData.user || !userData.pass) return
+  if (!userData || !userData.user || !userData.pass || !platform) return
 
   // local function so it's not easily called from elsewhere
   const encode = async (decoded) => {
@@ -624,7 +627,7 @@ async function getUserData (platform = 'zih') {
   const data = await new Promise((resolve) => chrome.storage.local.get(['udata'], (data) => resolve(data.udata)))
 
   // check if Data exists, else return
-  if (typeof data !== 'string') {
+  if (typeof data !== 'string' || !platform) {
     return ({ user: undefined, pass: undefined })
   }
 

--- a/src/background.js
+++ b/src/background.js
@@ -145,8 +145,11 @@ chrome.runtime.onInstalled.addListener(async (details) => {
             break
           }
           case 2: {
-            const userData = await getUserDataLagacy()
-            await setUserData(userData, 'zih')
+            const { asdf: user, fdsa: pass } = await getUserDataLagacy()
+            await setUserData({ user, pass }, 'zih')
+            // Delete old user data
+            // Promisified until usage of Manifest V3
+            await new Promise((resolve) => chrome.storage.local.remove(['Data'], resolve))
           }
         }
         updateObj.encryption_level = 3

--- a/src/contentScripts/cloudstore.js
+++ b/src/contentScripts/cloudstore.js
@@ -5,12 +5,12 @@ chrome.storage.local.get(['isEnabled', 'loggedOutCloudstore'], (result) => {
       if (document.getElementById('user') && document.getElementById('password')) {
         chrome.runtime.sendMessage({ cmd: 'get_user_data' }, async (result) => {
           await result
-          if (result.asdf && result.fdsa) {
+          if (result.user && result.pass) {
             chrome.runtime.sendMessage({ cmd: 'show_ok_badge', timeout: 2000 })
             chrome.runtime.sendMessage({ cmd: 'perform_login' })
             chrome.runtime.sendMessage({ cmd: 'save_clicks', click_count: 1 })
-            document.getElementById('user').value = result.asdf
-            document.getElementById('password').value = result.fdsa
+            document.getElementById('user').value = result.user
+            document.getElementById('password').value = result.pass
             document.getElementById('submit-form').click()
           } else {
             chrome.runtime.sendMessage({ cmd: 'no_login_data' })

--- a/src/contentScripts/gitlab.js
+++ b/src/contentScripts/gitlab.js
@@ -4,11 +4,11 @@ chrome.storage.local.get(['isEnabled', 'loggedOutGitlab'], (result) => {
       if (document.getElementById('username') && document.getElementById('password')) {
         chrome.runtime.sendMessage({ cmd: 'get_user_data' }, async (result) => {
           await result
-          if (result.asdf && result.fdsa) {
+          if (result.user && result.pass) {
             chrome.runtime.sendMessage({ cmd: 'save_clicks', click_count: 1 })
             chrome.runtime.sendMessage({ cmd: 'perform_login' })
-            document.getElementById('username').value = result.asdf
-            document.getElementById('password').value = result.fdsa
+            document.getElementById('username').value = result.user
+            document.getElementById('password').value = result.pass
             document.getElementsByTagName('input')[4].click()
           } else {
             chrome.runtime.sendMessage({ cmd: 'no_login_data' })

--- a/src/contentScripts/idp.js
+++ b/src/contentScripts/idp.js
@@ -15,10 +15,10 @@ function logInQis () {
   if (document.getElementById('username')) {
     chrome.runtime.sendMessage({ cmd: 'get_user_data' }, async (result) => {
       await result
-      if (result.fdsa && result.asdf) {
+      if (result.user && result.pass) {
         chrome.runtime.sendMessage({ cmd: 'save_clicks', click_count: 1 })
-        document.getElementById('username').value = result.asdf
-        document.getElementById('password').value = result.fdsa
+        document.getElementById('username').value = result.user
+        document.getElementById('password').value = result.pass
         document.getElementsByName('_eventId_proceed')[0].click()
       } else {
         chrome.runtime.sendMessage({ cmd: 'no_login_data' })

--- a/src/contentScripts/jexam.js
+++ b/src/contentScripts/jexam.js
@@ -4,12 +4,12 @@ chrome.storage.local.get(['isEnabled', 'loggedOutJexam'], (result) => {
       if (document.getElementById('username') && document.getElementById('password')) {
         chrome.runtime.sendMessage({ cmd: 'get_user_data' }, async (result) => {
           await result
-          if (result.asdf && result.fdsa) {
+          if (result.user && result.pass) {
             chrome.runtime.sendMessage({ cmd: 'show_ok_badge', timeout: 2000 })
             chrome.runtime.sendMessage({ cmd: 'save_clicks', click_count: 1 })
             chrome.runtime.sendMessage({ cmd: 'perform_login' })
-            document.getElementById('username').value = result.asdf
-            document.getElementById('password').value = result.fdsa
+            document.getElementById('username').value = result.user
+            document.getElementById('password').value = result.pass
             document.getElementsByTagName('input')[2].click()
           } else {
             chrome.runtime.sendMessage({ cmd: 'no_login_data' })

--- a/src/contentScripts/owa.js
+++ b/src/contentScripts/owa.js
@@ -38,12 +38,12 @@ function loginOWA () {
   if (document.getElementById('username') && document.getElementById('password')) {
     chrome.runtime.sendMessage({ cmd: 'get_user_data' }, async (result) => {
       await result
-      if (result.asdf && result.fdsa) {
+      if (result.user && result.pass) {
         chrome.runtime.sendMessage({ cmd: 'show_ok_badge', timeout: 2000 })
         chrome.runtime.sendMessage({ cmd: 'save_clicks', click_count: 1 })
         chrome.runtime.sendMessage({ cmd: 'perform_login' })
-        document.getElementById('username').value = result.asdf + '@msx.tu-dresden.de'
-        document.getElementById('password').value = result.fdsa
+        document.getElementById('username').value = result.user + '@msx.tu-dresden.de'
+        document.getElementById('password').value = result.pass
         document.getElementsByClassName('signinbutton')[0].click()
         chrome.runtime.sendMessage({ cmd: 'logged_out', portal: 'loggedOutOwa' })
       } else {

--- a/src/contentScripts/qis.js
+++ b/src/contentScripts/qis.js
@@ -20,12 +20,12 @@ function loginQis (isEnabled) {
   } else if (document.getElementById('asdf') && isEnabled) {
     chrome.runtime.sendMessage({ cmd: 'get_user_data' }, async (result) => {
       await result
-      if (result.asdf && result.fdsa) {
+      if (result.user && result.pass) {
         chrome.runtime.sendMessage({ cmd: 'show_ok_badge', timeout: 2000 })
         chrome.runtime.sendMessage({ cmd: 'save_clicks', click_count: 1 })
         chrome.runtime.sendMessage({ cmd: 'perform_login' })
-        document.getElementById('asdf').value = result.asdf
-        document.getElementById('fdsa').value = result.fdsa
+        document.getElementById('asdf').value = result.user
+        document.getElementById('fdsa').value = result.pass
         document.getElementsByName('submit')[0].click()
       } else {
         chrome.runtime.sendMessage({ cmd: 'no_login_data' })

--- a/src/contentScripts/selma.js
+++ b/src/contentScripts/selma.js
@@ -4,12 +4,12 @@ chrome.storage.local.get(['isEnabled', 'loggedOutSelma'], (result) => {
       if (document.getElementById('field_user')) {
         chrome.runtime.sendMessage({ cmd: 'get_user_data' }, async (response) => {
           await response
-          if (response.asdf && response.fdsa) {
+          if (response.user && response.pass) {
             chrome.runtime.sendMessage({ cmd: 'show_ok_badge', timeout: 2000 })
             chrome.runtime.sendMessage({ cmd: 'save_clicks', click_count: 1 })
             chrome.runtime.sendMessage({ cmd: 'perform_login' })
-            document.getElementById('field_user').value = response.asdf
-            document.getElementById('field_pass').value = response.fdsa
+            document.getElementById('field_user').value = response.user
+            document.getElementById('field_pass').value = response.pass
             document.getElementById('logIn_btn').click()
           } else {
             chrome.runtime.sendMessage({ cmd: 'no_login_data' })

--- a/src/contentScripts/tumed.js
+++ b/src/contentScripts/tumed.js
@@ -5,12 +5,12 @@ chrome.storage.local.get(['isEnabled', 'loggedOutTumed'], (result) => {
       if (document.querySelectorAll('label[for=__ac_name]')[0] && document.querySelectorAll('label[for=__ac_password]')[0] && document.getElementById('__ac_name') && document.getElementById('__ac_password')) {
         chrome.runtime.sendMessage({ cmd: 'get_user_data' }, async (result) => {
           await result
-          if (result.asdf && result.fdsa) {
+          if (result.user && result.pass) {
             chrome.runtime.sendMessage({ cmd: 'show_ok_badge', timeout: 2000 })
             chrome.runtime.sendMessage({ cmd: 'save_clicks', click_count: 2 })
             chrome.runtime.sendMessage({ cmd: 'perform_login' })
-            document.getElementById('__ac_name').value = result.asdf
-            document.getElementById('__ac_password').value = result.fdsa
+            document.getElementById('__ac_name').value = result.user
+            document.getElementById('__ac_password').value = result.pass
             document.querySelectorAll('input[value=Anmelden]')[0].click()
           } else {
             chrome.runtime.sendMessage({ cmd: 'no_login_data' })

--- a/src/freshContent/popup/popup.js
+++ b/src/freshContent/popup/popup.js
@@ -606,7 +606,7 @@ async function saveEnabled () {
   // Promisified until usage of Manifest V3
   const userData = await new Promise((resolve) => chrome.runtime.sendMessage({ cmd: 'get_user_data' }, resolve))
   await userData
-  if (userData.asdf && userData.fdsa) {
+  if (userData.user && userData.pass) {
     // Promisified until usage of Manifest V3
     await new Promise((resolve) => chrome.storage.local.set({ isEnabled: !(isEnabled.isEnabled) }, resolve))
   } else {

--- a/src/freshContent/popup/popup.js
+++ b/src/freshContent/popup/popup.js
@@ -604,6 +604,7 @@ async function saveEnabled () {
   // Promisified until usage of Manifest V3
   const isEnabled = await new Promise((resolve) => chrome.storage.local.get(['isEnabled'], resolve))
   // Promisified until usage of Manifest V3
+  // If there are multiple platforms user data has to be checked for every platform
   const userDataAvail = await new Promise((resolve) => chrome.runtime.sendMessage({ cmd: 'check_user_data' }, resolve))
   await userDataAvail
   if (userDataAvail) {

--- a/src/freshContent/popup/popup.js
+++ b/src/freshContent/popup/popup.js
@@ -604,9 +604,9 @@ async function saveEnabled () {
   // Promisified until usage of Manifest V3
   const isEnabled = await new Promise((resolve) => chrome.storage.local.get(['isEnabled'], resolve))
   // Promisified until usage of Manifest V3
-  const userData = await new Promise((resolve) => chrome.runtime.sendMessage({ cmd: 'get_user_data' }, resolve))
-  await userData
-  if (userData.user && userData.pass) {
+  const userDataAvail = await new Promise((resolve) => chrome.runtime.sendMessage({ cmd: 'check_user_data' }, resolve))
+  await userDataAvail
+  if (userDataAvail) {
     // Promisified until usage of Manifest V3
     await new Promise((resolve) => chrome.storage.local.set({ isEnabled: !(isEnabled.isEnabled) }, resolve))
   } else {

--- a/src/freshContent/settings/settings.html
+++ b/src/freshContent/settings/settings.html
@@ -62,9 +62,10 @@
       <input placeholder="Nutzername (selma-Login)" type="text" id="username_field"> <span id="user_extra_hint">(ohne @mailbox.tu-dresden.de. Also z.B. "s3276763" oder "luka075d")</span><br>
       <input placeholder="Passwort (selma-Login)" type="password" id="password_field"><br>
       <input type="button" class="button-accept btn--settings" id="save_data" value="Lokal Speichern" />
-      <p id="status_platform" style="display: inline;"></p><br>
-      <p id="status_msg" style="display: inline;"></p>
+      <p id="status_platform" style="display: inline;"></p>
     </form>
+    <hr>
+    <p id="status_msg" style="display: inline;"></p><br>
     <p>Hier kannst du alle Daten löschen:<br>
       <button id="delete_data" class="button-deny btn--settings">Alle Daten löschen</button>
     </p>

--- a/src/freshContent/settings/settings.html
+++ b/src/freshContent/settings/settings.html
@@ -48,7 +48,7 @@
   <!-- #region -->
   <button class="accordion btn--settings" id="auto_login_settings">Automatisches Anmelden in OPAL, selma & Co.</button>
   <div class="panel">
-    <p><b>Werde in alle Online-Portale der TU Dresden automatisch angemeldet.</b><br>Dafür müssen deine selma
+    <p><b>Werde in alle Online-Portale der TU Dresden automatisch angemeldet.</b><br>Dafür müssen deine
       Login-Daten sicher auf diesem PC gespeichert werden.<br>Die Daten werden nur lokal und verschlüsselt
       gespeichert.<br>
       Du kannst sie jederzeit löschen.<br>
@@ -56,7 +56,7 @@
     </p>
     <form>
       <!-- currently disabled as there is no other platform supported -->
-      <select name="platform" id="platform_select">
+      Plattform: <select name="platform" id="platform_select">
         <option value="zih">ZIH/Selma</option>
       </select><br>
       <input placeholder="Nutzername (selma-Login)" type="text" id="username_field"> <span id="user_extra_hint">(ohne @mailbox.tu-dresden.de. Also z.B. "s3276763" oder "luka075d")</span><br>

--- a/src/freshContent/settings/settings.html
+++ b/src/freshContent/settings/settings.html
@@ -56,12 +56,13 @@
     </p>
     <form>
       <!-- currently disabled as there is no other platform supported -->
-      <select name="platform" id="platform_select" disabled>
+      <select name="platform" id="platform_select">
         <option value="zih">ZIH/Selma</option>
       </select><br>
       <input placeholder="Nutzername (selma-Login)" type="text" id="username_field"> <span id="user_extra_hint">(ohne @mailbox.tu-dresden.de. Also z.B. "s3276763" oder "luka075d")</span><br>
       <input placeholder="Passwort (selma-Login)" type="password" id="password_field"><br>
-      <input type="submit" class="button-accept btn--settings" id="save_data" value="Lokal Speichern" />
+      <input type="button" class="button-accept btn--settings" id="save_data" value="Lokal Speichern" />
+      <p id="status_platform" style="display: inline;"></p><br>
       <p id="status_msg" style="display: inline;"></p>
     </form>
     <p>Hier kannst du alle Daten löschen:<br>

--- a/src/freshContent/settings/settings.html
+++ b/src/freshContent/settings/settings.html
@@ -55,9 +55,13 @@
       <span class="grey-text">TUfast nimmt dir auch alle Klicks beim Anmelden ab!</span>
     </p>
     <form>
-      <input placeholder="Nutzername (selma-Login)" type="text" id="username_field"> (ohne @mailbox.tu-dresden.de. Also z.B. "s3276763" oder "luka075d")<br>
+      <!-- currently disabled as there is no other platform supported -->
+      <select name="platform" id="platform_select" disabled>
+        <option value="zih">ZIH/Selma</option>
+      </select><br>
+      <input placeholder="Nutzername (selma-Login)" type="text" id="username_field"> <span id="user_extra_hint">(ohne @mailbox.tu-dresden.de. Also z.B. "s3276763" oder "luka075d")</span><br>
       <input placeholder="Passwort (selma-Login)" type="password" id="password_field"><br>
-      <button type="button" class="button-accept btn--settings" id="save_data">Lokal Speichern</button>
+      <input type="submit" class="button-accept btn--settings" id="save_data" value="Lokal Speichern" />
       <p id="status_msg" style="display: inline;"></p>
     </form>
     <p>Hier kannst du alle Daten löschen:<br>

--- a/src/freshContent/settings/settings.js
+++ b/src/freshContent/settings/settings.js
@@ -193,7 +193,7 @@ async function updateSavedStatus () {
     const dataSet = await new Promise((resolve) => chrome.runtime.sendMessage({ cmd: 'check_user_data', platform: platformName }, resolve))
     if (dataSet) dataSaved.push(platform.innerHTML)
   }
-  if (dataSaved === []) {
+  if (dataSaved.length === 0) {
     statusField.innerHTML = '<span class="grey-text">Derzeit sind keine Logindaten gespeichert.</span>'
   } else {
     statusField.innerHTML = `<span class="green-text">Derzeit gespeichert sind Logindaten für: ${dataSaved.join(', ')}</span>`

--- a/src/freshContent/settings/settings.js
+++ b/src/freshContent/settings/settings.js
@@ -34,7 +34,23 @@ async function nextTheme () {
   await applyTheme(themeOrder[idx])
 }
 
+async function changePlatform (e) {
+  const platform = e.target.value
+  let usernameExtraHint, usernameFieldHint, passwordFieldHint
+  switch (platform) {
+    case 'zih':
+      usernameFieldHint = 'Nutzername (selma-Login)'
+      passwordFieldHint = 'Passwort (selma-Login)'
+      usernameExtraHint = '(ohne @mailbox.tu-dresden.de. Also z.B. "s3276763" oder "luka075d")'
+      break
+  }
+  document.getElementById('username_field').setAttribute('placeholder', usernameFieldHint)
+  document.getElementById('password_field').setAttribute('placeholder', passwordFieldHint)
+  document.getElementById('user_extra_hint').innerHTML = usernameExtraHint
+}
+
 async function saveUserData () {
+  const platform = document.getElementById('platform_select')?.value || 'zih'
   const user = document.getElementById('username_field')?.value
   const pass = document.getElementById('password_field')?.value
   if (!user || !pass) {
@@ -44,7 +60,7 @@ async function saveUserData () {
     // Promisified until usage of Manifest V3
     await new Promise((resolve) => chrome.storage.local.set({ isEnabled: true }, resolve)) // need to activate auto login feature
     chrome.runtime.sendMessage({ cmd: 'clear_badge' })
-    chrome.runtime.sendMessage({ cmd: 'set_user_data', userData: { user, pass } })
+    chrome.runtime.sendMessage({ cmd: 'set_user_data', userData: { user, pass }, platform })
     document.getElementById('status_msg').innerHTML = ''
     document.getElementById('save_data').innerHTML = '<span>Gespeichert!</span>'
     document.getElementById('save_data').disabled = true
@@ -398,6 +414,7 @@ window.onload = async () => {
   await insertAllRocketIcons()
 
   // assign functions
+  document.getElementById('platform_select').onchange = changePlatform
   document.getElementById('save_data').onclick = saveUserData
   document.getElementById('delete_data').onclick = deleteUserData
   document.getElementById('switch_fwd').onclick = fwdGoogleSearch

--- a/src/freshContent/settings/settings.js
+++ b/src/freshContent/settings/settings.js
@@ -61,12 +61,12 @@ async function saveUserData () {
     // Promisified until usage of Manifest V3
     await new Promise((resolve) => chrome.storage.local.set({ isEnabled: true }, resolve)) // need to activate auto login feature
     chrome.runtime.sendMessage({ cmd: 'clear_badge' })
-    chrome.runtime.sendMessage({ cmd: 'set_user_data', userData: { user, pass }, platform })
+    await new Promise((resolve) => chrome.runtime.sendMessage({ cmd: 'set_user_data', userData: { user, pass }, platform }, resolve))
     document.getElementById('save_data').innerHTML = '<span>Gespeichert!</span>'
     document.getElementById('save_data').disabled = true
     document.getElementById('username_field').value = ''
     document.getElementById('password_field').value = ''
-    document.getElementById('status_platform').innerHTML = '<span class="green-text">Deine Zugangsdaten für diese Platform sind gespeichert!</span>'
+    await updatePlatformStatus(platform)
     await updateSavedStatus()
     setTimeout(() => {
       document.getElementById('save_data').innerHTML = 'Speichern'

--- a/src/freshContent/settings/settings.js
+++ b/src/freshContent/settings/settings.js
@@ -35,16 +35,16 @@ async function nextTheme () {
 }
 
 async function saveUserData () {
-  const asdf = document.getElementById('username_field')?.value
-  const fdsa = document.getElementById('password_field')?.value
-  if (!asdf || !fdsa) {
+  const user = document.getElementById('username_field')?.value
+  const pass = document.getElementById('password_field')?.value
+  if (!user || !pass) {
     document.getElementById('status_msg').innerHTML = '<span class="red-text">Die Felder d&uuml;rfen nicht leer sein!</span>'
     return false
   } else {
     // Promisified until usage of Manifest V3
     await new Promise((resolve) => chrome.storage.local.set({ isEnabled: true }, resolve)) // need to activate auto login feature
     chrome.runtime.sendMessage({ cmd: 'clear_badge' })
-    chrome.runtime.sendMessage({ cmd: 'set_user_data', userData: { asdf: asdf, fdsa: fdsa } })
+    chrome.runtime.sendMessage({ cmd: 'set_user_data', userData: { user, pass } })
     document.getElementById('status_msg').innerHTML = ''
     document.getElementById('save_data').innerHTML = '<span>Gespeichert!</span>'
     document.getElementById('save_data').disabled = true
@@ -221,7 +221,7 @@ async function enableOWAFetch () {
     const resp = await new Promise((resolve) => chrome.runtime.sendMessage({ cmd: 'get_user_data' }, resolve))
     const userData = await resp
     // check if user data is saved
-    if (userData.asdf && userData.fdsa) {
+    if (userData.user && userData.pass) {
       document.getElementById('owa_fetch_msg').innerHTML = ''
       // Promisified until usage of Manifest V3
       await new Promise((resolve) => chrome.storage.local.set({


### PR DESCRIPTION
### Pull Request

#### Description
I proprose the following changes in my PR:
- Encryption level is level 3
  - data is stored in local storage field `udata`
  - data is stored in format `{'platform (eg zih)': {'user': 'encrypted', 'pass': 'encrypted'}, ...}`
  - older levels will be automatically converted to new format
- `set_user_data` command _can_ user platform argument (default is zih)
- same for `get_user_data`
- new command `check_user_data` to check if userdata is set without fetching it in "frontend"
- `asdf` and `fdsa` are renamed to `user` and `pass` everywhere in code

Referenced Issue: close #65

Referenced ToDo from [project-board](https://github.com/orgs/TUfast-TUD/projects/1): [ToDo card](https://github.com/orgs/TUfast-TUD/projects/1#card-69514313)

#### Type of change
- [ ] Bug fix (non-breaking change which fixes a bug)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that might cause existing functionality to not work as expected)

#### Further info
- [ ] This change requires a documentation update
- [ ] I updated the documentation accordingly, if required
- [x] I commented my code where its useful

#### Testing
We have 1500+ Users. Please test your changes thoroughly.
- [ ] Tested my changes on Firefox
- [x] Tested my changes on Chromium-Based-Browsers
- [x] Successfully run `npm run test` locally

#### Additional Information
Although it _should_ work fine, be aware that testing this branch should be done in a extra environment as an downgrade is not possible.

The HTML-Select in the settings page is currently kind of ugly. Someone could fix this or we just wait for the new design.