### PR TITLE
Hide #fsr_link and #fsr_link_2 if no FSR is selected

### DIFF
--- a/src/freshContent/popup/popup.js
+++ b/src/freshContent/popup/popup.js
@@ -342,6 +342,7 @@ function customizeForStudiengang (studiengang) {
   // set fsr link
   if (studiengangConfig[studiengang].fsr_link) {
     document.getElementById('fsr_link').href = studiengangConfig[studiengang].fsr_link
+    document.getElementById('fsr_link').style.display = 'unset'
   } else {
     document.getElementById('fsr_link').style.display = 'none'
   }
@@ -349,6 +350,7 @@ function customizeForStudiengang (studiengang) {
   // set fsr link 2
   if (studiengangConfig[studiengang].fsr_link_2) {
     document.getElementById('fsr_link_2').href = studiengangConfig[studiengang].fsr_link_2
+    document.getElementById('fsr_link_2').style.display = 'unset'
   } else {
     document.getElementById('fsr_link_2').style.display = 'none'
   }

--- a/src/freshContent/popup/popup.js
+++ b/src/freshContent/popup/popup.js
@@ -342,11 +342,15 @@ function customizeForStudiengang (studiengang) {
   // set fsr link
   if (studiengangConfig[studiengang].fsr_link) {
     document.getElementById('fsr_link').href = studiengangConfig[studiengang].fsr_link
+  } else {
+    document.getElementById('fsr_link').style.display = 'none'
   }
 
   // set fsr link 2
   if (studiengangConfig[studiengang].fsr_link_2) {
     document.getElementById('fsr_link_2').href = studiengangConfig[studiengang].fsr_link_2
+  } else {
+    document.getElementById('fsr_link_2').style.display = 'none'
   }
 }
 

--- a/src/freshContent/popup/popup.js
+++ b/src/freshContent/popup/popup.js
@@ -88,7 +88,7 @@ const studiengangConfig = {
   general: {
     name: 'Standardeinstellungen',
     fsr_icon: '',
-    fsr_link: 'javascript: void(0)',
+    fsr_link: '',
     footer_icons_display: ['selma', 'opal', 'qis', 'matrix', 'msx', 'cloud', 'je', 'swdd'],
     footer_icons_links: {
       swdd: 'https://www.studentenwerk-dresden.de/mensen/speiseplan/'


### PR DESCRIPTION
### Pull Request

#### Description
I propose the following changes in my PR:
- Hide `#tud_link` and `#tud_link_2` if empty.

Before:
![image](https://user-images.githubusercontent.com/13350549/140617010-0644075c-e1c7-412a-bb5f-fa5bc8b07e26.png)

After:
![image](https://user-images.githubusercontent.com/13350549/140617037-5795fed5-1e09-4553-9870-20fcae258d84.png)


#### References
I created the PR because it bothered me that when I type a search query and press tab once/twice, the blank spots after the search bar are focused.

Referenced Issue: #78 

Referenced ToDo from [project-board](https://github.com/orgs/TUfast-TUD/projects/1): (none)

#### Type of change
- [x] Bug fix (non-breaking change which fixes a bug)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that might cause existing functionality to not work as expected)

#### Further info
- [ ] This change requires a documentation update
- [ ] I updated the documentation accordingly, if required
- [ ] I commented my code where its useful

#### Testing
We have 1500+ Users. Please test your changes thoroughly.
- [x] Tested my changes on Firefox
- [x] Tested my changes on Chromium-Based-Browsers
- [x] Successfully run `npm run test` locally

#### Additional Information
Add anything here, that might be important.
