### PR TITLE
Fix the settings button opening a blank window on FF

### DIFF
--- a/src/freshContent/popup/popup.html
+++ b/src/freshContent/popup/popup.html
@@ -103,7 +103,7 @@
         </a>
       </div>
       <div class="settings-section" style="flex: 1">
-        <a class="settings-section-icon" href="javascript:void(0)" id="settings" target="_blank"
+        <a class="settings-section-icon" href="javascript:void(0)" id="settings"
           style="flex: 1; margin: 0px">
           <img class="list-img" style="height: 20px;" src="../../assets/icons/cog.png">
         </a>


### PR DESCRIPTION
#### Description
I proprose the following changes in my PR:
- The settings button in the popup no longer opens a blank window on Firefox

#### Type of change
- [x] Bug fix (non-breaking change which fixes a bug)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that might cause existing functionality to not work as expected)

#### Further info
- [ ] This change requires a documentation update
- [ ] I updated the documentation accordingly, if required
- [ ] I commented my code where its useful

#### Testing
We have 1500+ Users. Please test your changes thoroughly.
- [x] Tested my changes on Firefox
- [x] Tested my changes on Chromium-Based-Browsers
- [x] Successfully run `npm run test` locally
