### PR TITLE
Show an outline when a switch is focused for better accessibility

### DIFF
--- a/src/styles/components/switch.scss
+++ b/src/styles/components/switch.scss
@@ -9,6 +9,12 @@
   height: 20px;
 }
 
+/* Outline of the focused switch */
+.switch:focus-within {
+  outline: 2px solid white;
+  border-radius: 34px;
+}
+
 /* Hide default HTML checkbox */
 .switch input {
   opacity: 0;


### PR DESCRIPTION
#### Description
I proprose the following changes in my PR:
- show an outline when a switch is focused for better accessibility
![Screenshot_20220131_155233](https://user-images.githubusercontent.com/21362942/151815551-fb0ffc74-df0a-4785-9c89-81096231534c.png)

#### Type of change
- [x] Bug fix (non-breaking change which fixes a bug)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that might cause existing functionality to not work as expected)

#### Further info
- [ ] This change requires a documentation update
- [ ] I updated the documentation accordingly, if required
- [x] I commented my code where its useful

#### Testing
We have 1500+ Users. Please test your changes thoroughly.
- [x] Tested my changes on Firefox
- [x] Tested my changes on Chromium-Based-Browsers
- [x] Successfully run `npm run test` locally
