### PR TITLE
Quick-fix: jExam login loop when "concurrentsession" error

### DIFF
--- a/src/contentScripts/login/jexam.ts
+++ b/src/contentScripts/login/jexam.ts
@@ -23,7 +23,7 @@ const cookieSettings: CookieSettings = {
 
     async findCredentialsError (): Promise<boolean | HTMLElement | Element | null> {
       const params = new URLSearchParams(window.location.search)
-      return params.get('error') === 'badcredentials' || params.get('error') === 'concurrentsession'
+      return params.get('error') !== null && params.get('error') !== ''
     }
 
     async loginFieldsAvailable (): Promise<boolean | LoginFields> {

--- a/src/contentScripts/login/jexam.ts
+++ b/src/contentScripts/login/jexam.ts
@@ -23,7 +23,7 @@ const cookieSettings: CookieSettings = {
 
     async findCredentialsError (): Promise<boolean | HTMLElement | Element | null> {
       const params = new URLSearchParams(window.location.search)
-      return params.get('error') === 'badcredentials'
+      return params.get('error') === 'badcredentials' || params.get('error') === 'concurrentsession'
     }
 
     async loginFieldsAvailable (): Promise<boolean | LoginFields> {


### PR DESCRIPTION
jExam is weird. When deleting the session cookie instead of logging out two times you cannot login anymore.

We can't fix that but we can fix that there are auto-reloads when TUfast is trying to re-login.

This PR is just changes one if clause so it should be save to push it to main.