### PR TITLE
Make notification container height fit-content instead of 50vh (fix f…

### DIFF
--- a/src/styles/components/notification.scss
+++ b/src/styles/components/notification.scss
@@ -3,7 +3,7 @@
   bottom: .8rem;
   right: .8rem;
   width: 25vw;
-  height: 50vh;
+  height: fit-content;
   z-index: 50;
 
   display: flex;


### PR DESCRIPTION
### Pull Request
#### Description
I proprose the following changes in my PR:
- Change height of notification container from `50vh` to `fit-content` so the container doesn't cover the lower half of the right side of the device screen and therefore blocks the underlying OPAL interface.

Referenced Issue: #129

#### Type of change
- [x] Bug fix (non-breaking change which fixes a bug)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that might cause existing functionality to not work as expected)

#### Further info
- [ ] This change requires a documentation update
- [ ] I updated the documentation accordingly, if required
- [ ] I commented my code where its useful

#### Testing
We have 1500+ Users. Please test your changes thoroughly.
- [ ] Tested my changes on Firefox
- [ ] Tested my changes on Chromium-Based-Browsers
- [ ] Successfully run `npm run test` locally

-> Not tested since the change is trivial and widely supported by browsers. 

