### PR TITLE
Add OTP support

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -1,5 +1,6 @@
 'use strict'
 import * as credentials from './modules/credentials'
+import * as otp from './modules/otp'
 import * as owaFetch from './modules/owaFetch'
 import * as opalInline from './modules/opalInline'
 import { isFirefox } from './modules/firefoxCheck'
@@ -225,6 +226,15 @@ chrome.runtime.onMessage.addListener((request, _sender, sendResponse) => {
       // Asynchronous response
       credentials.deleteUserData(request.platform).then(sendResponse) // Response can probably be ignored
       return true // required for async sendResponse
+    case 'get_totp':
+      // Asynchronous response
+      otp.getTOTP(request.platform).then(sendResponse)
+      return true // required for async sendResponse
+    case 'get_iotp':
+        // Asynchronous response
+        if (!request.indexes) return sendResponse(undefined)
+        otp.getIOTP(request.platform, ...request.indexes).then(sendResponse)
+        return true // required for async sendResponse
     /* OWA */
     case 'enable_owa_fetch':
       owaFetch.enableOWAFetch().then(sendResponse)

--- a/src/background.ts
+++ b/src/background.ts
@@ -231,10 +231,29 @@ chrome.runtime.onMessage.addListener((request, _sender, sendResponse) => {
       otp.getTOTP(request.platform).then(sendResponse)
       return true // required for async sendResponse
     case 'get_iotp':
-        // Asynchronous response
-        if (!request.indexes) return sendResponse(undefined)
-        otp.getIOTP(request.platform, ...request.indexes).then(sendResponse)
-        return true // required for async sendResponse
+      // Asynchronous response
+      if (!request.indexes) return sendResponse(undefined)
+      otp.getIOTP(request.platform, ...request.indexes).then(sendResponse)
+      return true // required for async sendResponse
+    case 'set_otp':
+      // Asynchronous response
+      switch (request.otpType) {
+        case 'totp': 
+          if (!request.secret) return sendResponse(false)
+          credentials.setUserData({user: 'totp', pass: request.secret}, (request.platform ?? 'zih') + '-totp').then(() => {
+            credentials.deleteUserData((request.platform ?? 'zih') + '-iotp').then(() => sendResponse(true))
+          })
+          return true // required for async sendResponse
+        
+        case 'iotp':
+          if (!request.secret) return sendResponse(false)
+          credentials.setUserData({user: 'iotp', pass: request.secret}, (request.platform ?? 'zih') + '-iotp').then(() => {
+            credentials.deleteUserData((request.platform ?? 'zih') + '-totp').then(() => sendResponse(true))
+          })
+          return true // required for async sendResponse
+        
+        default: return sendResponse(false)
+      }
     /* OWA */
     case 'enable_owa_fetch':
       owaFetch.enableOWAFetch().then(sendResponse)

--- a/src/background.ts
+++ b/src/background.ts
@@ -238,20 +238,20 @@ chrome.runtime.onMessage.addListener((request, _sender, sendResponse) => {
     case 'set_otp':
       // Asynchronous response
       switch (request.otpType) {
-        case 'totp': 
+        case 'totp':
           if (!request.secret) return sendResponse(false)
-          credentials.setUserData({user: 'totp', pass: request.secret}, (request.platform ?? 'zih') + '-totp').then(() => {
+          credentials.setUserData({ user: 'totp', pass: request.secret }, (request.platform ?? 'zih') + '-totp').then(() => {
             credentials.deleteUserData((request.platform ?? 'zih') + '-iotp').then(() => sendResponse(true))
           })
           return true // required for async sendResponse
-        
+
         case 'iotp':
           if (!request.secret) return sendResponse(false)
-          credentials.setUserData({user: 'iotp', pass: request.secret}, (request.platform ?? 'zih') + '-iotp').then(() => {
+          credentials.setUserData({ user: 'iotp', pass: request.secret }, (request.platform ?? 'zih') + '-iotp').then(() => {
             credentials.deleteUserData((request.platform ?? 'zih') + '-totp').then(() => sendResponse(true))
           })
           return true // required for async sendResponse
-        
+
         default: return sendResponse(false)
       }
     /* OWA */

--- a/src/contentScripts/login/common.ts
+++ b/src/contentScripts/login/common.ts
@@ -17,18 +17,18 @@ export interface CookieSettings {
   usesIdp?: boolean;
 }
 
-export interface LoginFields {
-  usernameField: HTMLInputElement;
-  passwordField: HTMLInputElement;
-  submitButton?: HTMLElement;
-  otpSettings?: OTPSettings;
-}
-
 interface OTPSettings {
   input: HTMLInputElement | null;
   submitButton?: HTMLElement | null;
   type: 'totp' | 'iotp';
   indexes?: number[];
+}
+
+export interface LoginFields {
+  usernameField: HTMLInputElement;
+  passwordField: HTMLInputElement;
+  submitButton?: HTMLElement;
+  otpSettings?: OTPSettings;
 }
 
 // This is the default lifetime for the logout cookie in minutes.
@@ -165,15 +165,15 @@ export abstract class Login {
     await this.login(userData, loginFields)
   }
 
-  async fillOtp(otpSettings: OTPSettings): Promise<boolean> {
+  async fillOtp (otpSettings: OTPSettings): Promise<boolean> {
     if (!otpSettings.input) return false
 
-    let otp: string | undefined = undefined;
+    let otp: string | undefined
     if (otpSettings.type === 'totp') {
       otp = await chrome.runtime.sendMessage({ cmd: 'get_totp', platform: this.platform })
     } else if (otpSettings.type === 'iotp') {
       otp = await chrome.runtime.sendMessage({ cmd: 'get_iotp', platform: this.platform, indexes: otpSettings.indexes })
-    } 
+    }
 
     if (!otp || otp.length === 0) return false
 

--- a/src/contentScripts/login/idp.ts
+++ b/src/contentScripts/login/idp.ts
@@ -61,7 +61,7 @@ const cookieSettings: CookieSettings = {
 
       const otpInput = document.getElementById('fudis_otp_input') as HTMLInputElement | null
       if (otpInput) {
-        const indexesText = otpInput.parentElement?.parentElement?.querySelector('td:first-of-type')?.textContent?.trim();
+        const indexesText = otpInput.parentElement?.parentElement?.querySelector('td:first-of-type')?.textContent?.trim()
         //                            find number & number | remove whole match | to numbers | to zero based (first index is 0)
         const indexes = indexesText?.match(/(\d+) & (\d+)/)?.slice(1, 3).map((x) => Number.parseInt(x, 10) - 1)
 

--- a/src/contentScripts/login/idp.ts
+++ b/src/contentScripts/login/idp.ts
@@ -22,6 +22,7 @@ const cookieSettings: CookieSettings = {
     async additionalFunctionsPostCheck (): Promise<void> {
       this.confirmData()
       this.outdatedRequest()
+      this.selectOTPType()
     }
 
     confirmData () {
@@ -29,8 +30,8 @@ const cookieSettings: CookieSettings = {
       if (!document.getElementById('generalConsentDiv')) return
 
       // Click the button
-      const button = document.querySelector('input[type="submit"][name="_eventId_proceed"]')
-      if (button) (button as HTMLInputElement).click()
+      const button = document.querySelector('input[type="submit"][name="_eventId_proceed"]') as HTMLInputElement | null
+      button?.click()
     }
 
     outdatedRequest () {
@@ -40,16 +41,40 @@ const cookieSettings: CookieSettings = {
       // We don't know where the user tried to login, so we can't jsut redirect to Opal/etc
     }
 
+    selectOTPType () {
+      if (!document.getElementById('fudis_selected_token_ids_input')) return
+
+      const button = document.querySelector('button[type="submit"][name="_eventId_proceed"]') as HTMLButtonElement | null
+      button?.click()
+    }
+
     async findCredentialsError (): Promise<boolean | HTMLElement | Element | null> {
       return document.querySelector('.content p font[color="red"]')
     }
 
     async loginFieldsAvailable (): Promise<boolean | LoginFields> {
-      return {
+      const fields: LoginFields = {
         usernameField: document.getElementById('username') as HTMLInputElement,
         passwordField: document.getElementById('password') as HTMLInputElement,
-        submitButton: document.querySelector('button[name="_eventId_proceed"][value="Login"]') as HTMLButtonElement
+        submitButton: document.querySelector('button[name="_eventId_proceed"][type="submit"]') as HTMLButtonElement
       }
+
+      const otpInput = document.getElementById('fudis_otp_input') as HTMLInputElement | null
+      if (otpInput) {
+        const indexesText = otpInput.parentElement?.parentElement?.querySelector('td:first-of-type')?.textContent?.trim();
+        //                            find number & number | remove whole match | to numbers | to zero based (first index is 0)
+        const indexes = indexesText?.match(/(\d+) & (\d+)/)?.slice(1, 3).map((x) => Number.parseInt(x, 10) - 1)
+
+        fields.otpSettings = {
+          input: otpInput,
+          submitButton: document.querySelector('button[name="_eventId_proceed"][type="submit"]') as HTMLButtonElement | null,
+          type: indexesText?.toLocaleLowerCase().includes('totp') ? 'totp' : 'iotp',
+          indexes: indexes && indexes.length > 0 ? indexes : undefined
+        }
+        console.log(fields)
+      }
+
+      return fields
     }
 
     async findLogoutButtons (): Promise<(HTMLElement|Element|null)[] | NodeList | null> {

--- a/src/contentScripts/other/otpSnatcher.ts
+++ b/src/contentScripts/other/otpSnatcher.ts
@@ -4,21 +4,21 @@ const seedLink = document.querySelector('#seed-link a[href^="otpauth://totp/"]')
 const indexedAvailable = document.getElementById('indexed-secret')
 
 if (qrAvailable && seedLink && showWarning()) {
-  const seed = seedLink.getAttribute('href');
+  const seed = seedLink.getAttribute('href')
   if (seed) {
     const secret = new URL(seed).searchParams.get('secret')
-    chrome.runtime.sendMessage({ cmd: 'set_otp', otpType: 'totp', secret, platform: "zih" })
+    chrome.runtime.sendMessage({ cmd: 'set_otp', otpType: 'totp', secret, platform: 'zih' })
   }
 } else if (!!indexedAvailable && showWarning()) {
-  const cols = indexedAvailable.querySelectorAll('tr:nth-of-type(2) td') as NodeListOf<HTMLTableCellElement>
+  const cols = Array.from(indexedAvailable.querySelectorAll('tr:nth-of-type(2) td'))
   // Maybe the ZIH will change the number of chars in the future
   // Update it here!
   if (cols.length === 25) {
-    const secret = Array.from(cols).map((col) => col.innerText).reduce((acc, cur) => acc + cur, '')
-    chrome.runtime.sendMessage({ cmd: 'set_otp', otpType: 'iotp', secret, platform: "zih" })
+    const secret = cols.map((col) => (col as HTMLTableCellElement).innerText).reduce((acc, cur) => acc + cur, '')
+    chrome.runtime.sendMessage({ cmd: 'set_otp', otpType: 'iotp', secret, platform: 'zih' })
   }
 }
 
-function showWarning(): boolean {
+function showWarning (): boolean {
   return confirm('TUfast kann diesen 2-Faktor-Code für dich speichern und automatisch an den entsprechenden Stellen einf\u00fcgen. Dies geht jedoch gegen den Sinn eines zweiten Faktors und ist noch in Entwicklung.\n\nSPEICHERE DIR DEN CODE UND DIE RECOVERY CODES AUF JEDEN FALL AUCH AN EINER ANDEREN STELLE!\n\nSoll TUfast für dich die 2-Faktor-Authentifizierung \u00fcbernehmen?')
 }

--- a/src/contentScripts/other/otpSnatcher.ts
+++ b/src/contentScripts/other/otpSnatcher.ts
@@ -7,7 +7,7 @@ if (qrAvailable && seedLink && showWarning()) {
   const seed = seedLink.getAttribute('href');
   if (seed) {
     const secret = new URL(seed).searchParams.get('secret')
-    chrome.runtime.sendMessage({ cmd: 'set_user_data', userData: { user: "totp", pass: secret }, platform: "zih-totp" })
+    chrome.runtime.sendMessage({ cmd: 'set_otp', otpType: 'totp', secret, platform: "zih" })
   }
 } else if (!!indexedAvailable && showWarning()) {
   const cols = indexedAvailable.querySelectorAll('tr:nth-of-type(2) td') as NodeListOf<HTMLTableCellElement>
@@ -15,7 +15,7 @@ if (qrAvailable && seedLink && showWarning()) {
   // Update it here!
   if (cols.length === 25) {
     const secret = Array.from(cols).map((col) => col.innerText).reduce((acc, cur) => acc + cur, '')
-    chrome.runtime.sendMessage({ cmd: 'set_user_data', userData: { user: "iotp", pass: secret }, platform: "zih-iotp" })
+    chrome.runtime.sendMessage({ cmd: 'set_otp', otpType: 'iotp', secret, platform: "zih" })
   }
 }
 

--- a/src/contentScripts/other/otpSnatcher.ts
+++ b/src/contentScripts/other/otpSnatcher.ts
@@ -19,5 +19,5 @@ if (qrAvailable && seedLink && showWarning()) {
 }
 
 function showWarning(): boolean {
-  return confirm('TUfast kann diesen 2-Faktor-Code für dich speichern und automatisch an den entsprechenden einfügen. Dies geht jedoch gegen den Sinn eines zweiten Faktors und ist noch in Entwicklung.\n\nSPEICHERE DIR DEN CODE AUF JEDEN FALL AUCH AN EINER ANDEREN STELLE!\n\nSoll TUfast für dich die 2-Faktor-Authentifizierung übernehmen?')
+  return confirm('TUfast kann diesen 2-Faktor-Code für dich speichern und automatisch an den entsprechenden Stellen einf\u00fcgen. Dies geht jedoch gegen den Sinn eines zweiten Faktors und ist noch in Entwicklung.\n\nSPEICHERE DIR DEN CODE AUF JEDEN FALL AUCH AN EINER ANDEREN STELLE!\n\nSoll TUfast für dich die 2-Faktor-Authentifizierung \u00fcbernehmen?')
 }

--- a/src/contentScripts/other/otpSnatcher.ts
+++ b/src/contentScripts/other/otpSnatcher.ts
@@ -1,0 +1,23 @@
+const qrAvailable = !!document.getElementById('qr-code')
+const seedLink = document.querySelector('#seed-link a[href="otpauth://totp/"]')
+
+const indexedAvailable = document.getElementById('indexed-secret')
+
+if (qrAvailable && seedLink && showWarning()) {
+  const seed = seedLink.getAttribute('href');
+  if (seed) {
+    chrome.runtime.sendMessage({ cmd: 'set_user_data', userData: { user: "totp", pass: seed }, platform: "zih-totp" })
+  }
+} else if (!!indexedAvailable && showWarning()) {
+  const cols = indexedAvailable.querySelectorAll('tr:nth-of-type(2) td') as NodeListOf<HTMLTableCellElement>
+  // Maybe the ZIH will change the number of chars in the future
+  // Update it here!
+  if (cols.length === 25) {
+    const secret = Array.from(cols).map((col) => col.innerText).reduce((acc, cur) => acc + cur, '')
+    chrome.runtime.sendMessage({ cmd: 'set_user_data', userData: { user: "iotp", pass: secret }, platform: "zih-iotp" })
+  }
+}
+
+function showWarning(): boolean {
+  return confirm('TUfast kann diesen 2-Faktor-Code für dich speichern und automatisch an den entsprechenden einfügen. Dies geht jedoch gegen den Sinn eines zweiten Faktors und ist noch in Entwicklung.\n\nSPEICHERE DIR DEN CODE AUF JEDEN FALL AUCH AN EINER ANDEREN STELLE!\n\nSoll TUfast für dich die 2-Faktor-Authentifizierung übernehmen?')
+}

--- a/src/contentScripts/other/otpSnatcher.ts
+++ b/src/contentScripts/other/otpSnatcher.ts
@@ -1,12 +1,13 @@
 const qrAvailable = !!document.getElementById('qr-code')
-const seedLink = document.querySelector('#seed-link a[href="otpauth://totp/"]')
+const seedLink = document.querySelector('#seed-link a[href^="otpauth://totp/"]')
 
 const indexedAvailable = document.getElementById('indexed-secret')
 
 if (qrAvailable && seedLink && showWarning()) {
   const seed = seedLink.getAttribute('href');
   if (seed) {
-    chrome.runtime.sendMessage({ cmd: 'set_user_data', userData: { user: "totp", pass: seed }, platform: "zih-totp" })
+    const secret = new URL(seed).searchParams.get('secret')
+    chrome.runtime.sendMessage({ cmd: 'set_user_data', userData: { user: "totp", pass: secret }, platform: "zih-totp" })
   }
 } else if (!!indexedAvailable && showWarning()) {
   const cols = indexedAvailable.querySelectorAll('tr:nth-of-type(2) td') as NodeListOf<HTMLTableCellElement>

--- a/src/contentScripts/other/otpSnatcher.ts
+++ b/src/contentScripts/other/otpSnatcher.ts
@@ -20,5 +20,5 @@ if (qrAvailable && seedLink && showWarning()) {
 }
 
 function showWarning(): boolean {
-  return confirm('TUfast kann diesen 2-Faktor-Code für dich speichern und automatisch an den entsprechenden Stellen einf\u00fcgen. Dies geht jedoch gegen den Sinn eines zweiten Faktors und ist noch in Entwicklung.\n\nSPEICHERE DIR DEN CODE AUF JEDEN FALL AUCH AN EINER ANDEREN STELLE!\n\nSoll TUfast für dich die 2-Faktor-Authentifizierung \u00fcbernehmen?')
+  return confirm('TUfast kann diesen 2-Faktor-Code für dich speichern und automatisch an den entsprechenden Stellen einf\u00fcgen. Dies geht jedoch gegen den Sinn eines zweiten Faktors und ist noch in Entwicklung.\n\nSPEICHERE DIR DEN CODE UND DIE RECOVERY CODES AUF JEDEN FALL AUCH AN EINER ANDEREN STELLE!\n\nSoll TUfast für dich die 2-Faktor-Authentifizierung \u00fcbernehmen?')
 }

--- a/src/manifest.chrome.json
+++ b/src/manifest.chrome.json
@@ -203,6 +203,11 @@
       "js": ["contentScripts/forward/searchEngines/startpage.js"],
       "run_at": "document_idle",
       "matches": ["https://www.startpage.com/*"]
+    },
+    {
+      "js": ["contentScripts/other/otpSnatcher.js"],
+      "run_at": "document_idle",
+      "matches": ["https://selfservice.tu-dresden.de/services/idm/token/create"]
     }
   ],
   "icons": {

--- a/src/manifest.firefox.json
+++ b/src/manifest.firefox.json
@@ -17,7 +17,8 @@
     "*://*/"
   ],
   "background": {
-    "page": "background.html"
+    "scripts": ["background.js"],
+    "type": "module"
   },
   "content_scripts": [
     {
@@ -202,6 +203,11 @@
       "js": ["contentScripts/forward/searchEngines/startpage.js"],
       "run_at": "document_idle",
       "matches": ["https://www.startpage.com/*"]
+    },
+    {
+      "js": ["contentScripts/other/otpSnatcher.js"],
+      "run_at": "document_idle",
+      "matches": ["https://selfservice.tu-dresden.de/services/idm/token/create"]
     }
   ],
   "icons": {

--- a/src/modules/otp.ts
+++ b/src/modules/otp.ts
@@ -1,0 +1,84 @@
+import { getUserData } from "./credentials"
+
+// Get the TOTP code for the user
+export async function getTOTP(platform: string = 'zih'): Promise<string|undefined> {
+    const userData = await getUserData(platform + '-totp')
+    try {
+        if (!userData || !userData.pass) return undefined
+        return await generateTOTP(userData.pass ?? '')
+    } catch {
+        return undefined
+    }
+}
+
+export async function getIOTP(platform: string = 'zih', ...indexes): Promise<string|undefined> {
+    const userData = await getUserData(platform + '-iotp')
+    if (!userData || !userData.pass) return undefined
+
+    let result = ''
+    for (const index of indexes) {
+        const char = userData.pass[index]
+        if (!char) return undefined
+        result += char
+    }
+    return result
+}
+
+// Generate a TOTP code from a seed URI
+// Returns a string as it can be prefixed with 0s
+async function generateTOTP(secret: string): Promise<string> {
+
+    if (!secret) {
+        throw new Error('No secret found in URI')
+    }
+
+    // Counter is the current time in seconds divided by the interval
+    // Interval is 30 for the TUD
+    const counter = Math.floor((Date.now() / 1000) / 30) 
+
+    const key = await b32ToUInt8Arr(secret)
+    const value = new ArrayBuffer(8);
+    const view = new DataView(value);
+    view.setUint32(4, counter, false);
+
+    const cryptoKey = await crypto.subtle.importKey('raw', key, { name: 'HMAC', hash: 'SHA-1' }, false, ['sign', 'verify'])
+    const signed = await crypto.subtle.sign({ name: 'HMAC', hash: 'SHA-1' }, cryptoKey, value)
+
+    // Truncate the result
+    const signature = new Uint8Array(signed)
+    const offset = signature[signature.length - 1] & 0xf
+    const code = (signature[offset + 0] & 0x7f) << 24 | (signature[offset + 1] & 0xff) << 16 | (signature[offset + 2] & 0xff) << 8 | (signature[offset + 3] & 0xff);
+    //         because 6 digits v
+    return (code % Math.pow(10, 6)).toString().padStart(6, '0');
+}
+
+async function b32ToUInt8Arr(base32: string): Promise<Uint8Array> {
+    base32 = base32.replace(/=+$/, "").toLocaleUpperCase()
+    
+    /**
+     * How this works:
+     * - Convert each base32 character to a value.
+     * - Each value is 5bits long (because of 32 available chars).
+     * - We want bytes, but thats 8bits.
+     * - So get all the 5bit values, and concat them into a string.
+     * - Then get chunks of 8 from the string and parse the numeric value.
+     */
+
+    const base32Chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ234567'
+    let bits = ''
+
+    for (let i = 0; i < base32.length; i++) {
+		let val = base32Chars.indexOf(base32.charAt(i))
+		if (val === -1) throw new Error('Invalid character in secret')
+		bits += val.toString(2).padStart(5, '0')
+	}
+
+    const result = new Uint8Array(bits.length / 8)
+
+	for (let i = 0; i + 8 <= bits.length; i += 8) {
+		let chunk = bits.substring(i, i + 8)
+		result[i / 8] = Number.parseInt(chunk, 2)
+	}
+
+    return result
+}

--- a/src/modules/otp.ts
+++ b/src/modules/otp.ts
@@ -1,61 +1,60 @@
-import { getUserData } from "./credentials"
+import { getUserData } from './credentials'
 
 // Get the TOTP code for the user
-export async function getTOTP(platform: string = 'zih'): Promise<string|undefined> {
-    const userData = await getUserData(platform + '-totp')
-    try {
-        if (!userData || !userData.pass) return undefined
-        return await generateTOTP(userData.pass ?? '')
-    } catch {
-        return undefined
-    }
+export async function getTOTP (platform: string = 'zih'): Promise<string|undefined> {
+  const userData = await getUserData(platform + '-totp')
+  try {
+    if (!userData || !userData.pass) return undefined
+    return await generateTOTP(userData.pass ?? '')
+  } catch {
+    return undefined
+  }
 }
 
-export async function getIOTP(platform: string = 'zih', ...indexes): Promise<string|undefined> {
-    const userData = await getUserData(platform + '-iotp')
-    if (!userData || !userData.pass) return undefined
+export async function getIOTP (platform: string = 'zih', ...indexes): Promise<string|undefined> {
+  const userData = await getUserData(platform + '-iotp')
+  if (!userData || !userData.pass) return undefined
 
-    let result = ''
-    for (const index of indexes) {
-        const char = userData.pass[index]
-        if (!char) return undefined
-        result += char
-    }
-    return result
+  let result = ''
+  for (const index of indexes) {
+    const char = userData.pass[index]
+    if (!char) return undefined
+    result += char
+  }
+  return result
 }
 
 // Generate a TOTP code from a seed URI
 // Returns a string as it can be prefixed with 0s
-async function generateTOTP(secret: string): Promise<string> {
+async function generateTOTP (secret: string): Promise<string> {
+  if (!secret) {
+    throw new Error('No secret found in URI')
+  }
 
-    if (!secret) {
-        throw new Error('No secret found in URI')
-    }
+  // Counter is the current time in seconds divided by the interval
+  // Interval is 30 for the TUD
+  const counter = Math.floor((Date.now() / 1000) / 30)
 
-    // Counter is the current time in seconds divided by the interval
-    // Interval is 30 for the TUD
-    const counter = Math.floor((Date.now() / 1000) / 30) 
+  const key = await b32ToUInt8Arr(secret)
+  const value = new ArrayBuffer(8)
+  const view = new DataView(value)
+  view.setUint32(4, counter, false)
 
-    const key = await b32ToUInt8Arr(secret)
-    const value = new ArrayBuffer(8);
-    const view = new DataView(value);
-    view.setUint32(4, counter, false);
+  const cryptoKey = await crypto.subtle.importKey('raw', key, { name: 'HMAC', hash: 'SHA-1' }, false, ['sign', 'verify'])
+  const signed = await crypto.subtle.sign({ name: 'HMAC', hash: 'SHA-1' }, cryptoKey, value)
 
-    const cryptoKey = await crypto.subtle.importKey('raw', key, { name: 'HMAC', hash: 'SHA-1' }, false, ['sign', 'verify'])
-    const signed = await crypto.subtle.sign({ name: 'HMAC', hash: 'SHA-1' }, cryptoKey, value)
-
-    // Truncate the result
-    const signature = new Uint8Array(signed)
-    const offset = signature[signature.length - 1] & 0xf
-    const code = (signature[offset + 0] & 0x7f) << 24 | (signature[offset + 1] & 0xff) << 16 | (signature[offset + 2] & 0xff) << 8 | (signature[offset + 3] & 0xff);
-    //         because 6 digits v
-    return (code % Math.pow(10, 6)).toString().padStart(6, '0');
+  // Truncate the result
+  const signature = new Uint8Array(signed)
+  const offset = signature[signature.length - 1] & 0xf
+  const code = (signature[offset + 0] & 0x7f) << 24 | (signature[offset + 1] & 0xff) << 16 | (signature[offset + 2] & 0xff) << 8 | (signature[offset + 3] & 0xff)
+  //         because 6 digits v
+  return (code % Math.pow(10, 6)).toString().padStart(6, '0')
 }
 
-async function b32ToUInt8Arr(base32: string): Promise<Uint8Array> {
-    base32 = base32.replace(/=+$/, "").toLocaleUpperCase()
-    
-    /**
+async function b32ToUInt8Arr (base32: string): Promise<Uint8Array> {
+  base32 = base32.replace(/=+$/, '').toLocaleUpperCase()
+
+  /**
      * How this works:
      * - Convert each base32 character to a value.
      * - Each value is 5bits long (because of 32 available chars).
@@ -64,21 +63,21 @@ async function b32ToUInt8Arr(base32: string): Promise<Uint8Array> {
      * - Then get chunks of 8 from the string and parse the numeric value.
      */
 
-    const base32Chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ234567'
-    let bits = ''
+  const base32Chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ234567'
+  let bits = ''
 
-    for (let i = 0; i < base32.length; i++) {
-		let val = base32Chars.indexOf(base32.charAt(i))
-		if (val === -1) throw new Error('Invalid character in secret')
-		bits += val.toString(2).padStart(5, '0')
-	}
+  for (let i = 0; i < base32.length; i++) {
+    const val = base32Chars.indexOf(base32.charAt(i))
+    if (val === -1) throw new Error('Invalid character in secret')
+    bits += val.toString(2).padStart(5, '0')
+  }
 
-    const result = new Uint8Array(bits.length / 8)
+  const result = new Uint8Array(bits.length / 8)
 
-	for (let i = 0; i + 8 <= bits.length; i += 8) {
-		let chunk = bits.substring(i, i + 8)
-		result[i / 8] = Number.parseInt(chunk, 2)
-	}
+  for (let i = 0; i + 8 <= bits.length; i += 8) {
+    const chunk = bits.substring(i, i + 8)
+    result[i / 8] = Number.parseInt(chunk, 2)
+  }
 
-    return result
+  return result
 }


### PR DESCRIPTION
### Pull Request

#### Description
This PR will add OTP support to TUfast where the secret is stored, and the values automatically filled on login.

Although this makes 2FA kinda useless, the fact that 2FA will be forced, and that this feature was requested multiple times means it should be added.
Also, currently the really critical logins (HISQIS/jExam/Selma) are not even secured by 2FA.

#### References

Closes #127

#### Type of change
- [ ] Bug fix (non-breaking change which fixes a bug)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that might cause existing functionality to not work as expected)

#### Further info
- [ ] This change requires a documentation update
- [x] I updated the documentation accordingly, if required
- [x] I commented my code where its useful

#### Testing
We have 1500+ Users. Please test your changes thoroughly.
- [x] Tested my changes on Firefox
- [ ] Tested my changes on Chromium-Based-Browsers
- [x] Successfully run `npm run test` locally

#### Additional Information

When testing this, please be careful when creating new tokens!! Always save them in another location!
