### PR TITLE
Fix npm commands

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,7 @@ Steps to contribute:
 2. Checkout develop branch `git checkout develop`
 3. Create new feature branch from develop `git checkout -b <my_new_feature_branch>`
 4. Install dependencies `npm ci` - you need node package manager npm installed
-5. Run `npm useChrome` or `npm useFF` to select the browser you are developing for - this will copy the corresponding manifest.json
+5. Run `npm run useChrome` or `npm run useFF` to select the browser you are developing for - this will copy the corresponding manifest.json
 6. Run `npm run dev` while developing. This is will compile sass and ts files and watch for changes in your working tree.
 7. Load the ./build directory as an unpacked extension in your browser
 8. Run tests locally before committing code `npm run test`


### PR DESCRIPTION
#### Description
This PR corrects the wrong npm commands in the `CONTRIBUTING.md` file. Running `npm useFF` will throw an error as the correct command is `npm run useFF`.

#### References
```
Unknown command: "useFF"

Did you mean this?
    npm run useFF # run the "useFF" package script

To see a list of supported npm commands, run:
  npm help
```

#### Type of change
- [x] Bug fix (non-breaking change which fixes a bug)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that might cause existing functionality to not work as expected)