### PR TITLE
Fix/npm test

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -6,23 +6,26 @@ name: Test and Build
 on:
   push:
     branches:
-     - main
-     - develop
+      - main
+      - develop
   pull_request:
     branches:
-     - main
-     - develop
+      - main
+      - develop
 jobs:
   build:
-
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Use Node.js 16
-      uses: actions/setup-node@v2
-      with:
-        node-version: '16.x'
-        cache: 'npm'
-    - run: npm ci
-    - run: npm run test
+      - uses: actions/checkout@v2
+      - name: Use Node.js 16
+        uses: actions/setup-node@v2
+        with:
+          node-version: "16.x"
+          cache: "npm"
+      # Install dependencies
+      - run: npm ci
+      # Use chrome manifest
+      - run: npm useChrome
+      # Run tests
+      - run: npm run test

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -26,6 +26,6 @@ jobs:
       # Install dependencies
       - run: npm ci
       # Use chrome manifest
-      - run: npm useChrome
+      - run: npm run useChrome
       # Run tests
       - run: npm run test

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "index.js",
   "scripts": {
     "lint": "npx eslint --ext .js,.ts,.vue --fix .",
-    "test": "npm run lint && npm run build",
+    "ts-check": "npx tsc --noEmit",
+    "test": "npm run ts-check && npm run lint && npm run build",
     "dev": "snowpack build --watch",
     "build": "snowpack build",
     "useChrome": "cp src/manifest.chrome.json src/manifest.json",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "lint": "npx eslint --ext .js,.ts,.vue --fix .",
-    "test": "npm run lint && npm run useChrome && npm run build",
+    "test": "npm run lint && npm run build",
     "dev": "snowpack build --watch",
     "build": "snowpack build",
     "useChrome": "cp src/manifest.chrome.json src/manifest.json",

--- a/src/contentScripts/other/hisqis/newTable.ts
+++ b/src/contentScripts/other/hisqis/newTable.ts
@@ -109,6 +109,10 @@ import { DataTable } from 'simple-datatables'
 
   oldTable.parentNode?.insertBefore(newTable, oldTable)
 
+  // If "TS2578: Unused '@ts-expect-error' directive" appears then they probably fixxed their typescript
+  // definition and the following @ts-expect-error directive should be removed.
+  // See: https://fiduswriter.github.io/simple-datatables/documentation/Getting-Started#browser
+  // @ts-expect-error
   // eslint-disable-next-line no-unused-vars
   const _dataTable = new DataTable(newTable, {
     sortable: true,


### PR DESCRIPTION
### Description

#### NPM test script
Currently the `test` script is defined as `npm run lint && npm run useChrome && npm run build`. Every time a developer will run `npm run test` they will automatically also run `npm run useChrome`. On linux this will override the existing `manifest.json` therefore making it extremely annoying to keep the Firefox manifest. This should not be the default behavior for a test.
I also changed the workflow from implicitly using the chrome manifest through the `npm run test` command to explicitly using the chrome config.

#### Typescript
I created the PR because this projects uses typescript but those typescript files never actually get checked. For example the file[ `src/contentScripts/other/hisqis/newTable.ts`](https://github.com/TUfast-TUD/TUfast_TUD/blob/755db8bee6bfdc7032a0af41fbf7c0e89ec3b3d4/src/contentScripts/other/hisqis/newTable.ts#L113) will throw a error on Line 113 if you run tsc.
With this PR every time the test script gets run it will additionally do a typescript check through the `tsc --noEmit` command. This also means that the test script will fail locally and in CI when a typescript error is detected. 

#### Type of change
- [ ] Bug fix (non-breaking change which fixes a bug)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that might cause existing functionality to not work as expected)
- [x] Testing scripts

#### Further info
- [ ] This change requires a documentation update
- [ ] I updated the documentation accordingly, if required
- [x] I commented my code where its useful

#### Testing
- [x] Tested my changes on Firefox
- [ ] Tested my changes on Chromium-Based-Browsers
- [x] Successfully run `npm run test` locally