### PR TITLE
ipd: Fix checking for totp type

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -222,11 +222,11 @@ chrome.runtime.onMessage.addListener((request, _sender, sendResponse) => {
       // Asynchronous response
       Promise.all([
         credentials.userDataExists(request.platform),
-        credentials.userDataExists(request.platform + "-totp"),
-        credentials.userDataExists(request.platform + "-iotp")
+        credentials.userDataExists(request.platform + '-totp'),
+        credentials.userDataExists(request.platform + '-iotp')
       ]).then(([loginExists, totpExists, iotpExists]) => {
         sendResponse(loginExists || totpExists || iotpExists)
-      });
+      })
       return true // required for async sendResponse
     case 'delete_user_data':
       // Asynchronous response

--- a/src/contentScripts/login/idp.ts
+++ b/src/contentScripts/login/idp.ts
@@ -61,7 +61,9 @@ const cookieSettings: CookieSettings = {
 
       const otpInput = document.getElementById('fudis_otp_input') as HTMLInputElement | null
       if (otpInput) {
-        const indexesText = otpInput.parentElement?.parentElement?.querySelector('td:first-of-type')?.textContent?.trim()
+        const indexesText = otpInput.parentElement?.parentElement?.parentElement
+          ?.querySelector('div:first-of-type')
+          ?.textContent?.trim()
         //                            find number & number | remove whole match | to numbers | to zero based (first index is 0)
         const indexes = indexesText?.match(/(\d+) & (\d+)/)?.slice(1, 3).map((x) => Number.parseInt(x, 10) - 1)
 

--- a/src/freshContent/settings/settingPages/AutoLogin.vue
+++ b/src/freshContent/settings/settingPages/AutoLogin.vue
@@ -49,7 +49,10 @@
       Zwei-Faktor-Authentisierung (2FA): Das Automatische Anmelden unterstützt auch 2FA. Hier kannst du dafür deinen TOTP Secret-Key speichern.
       Der Key ist Base32 enkodiert und sieht bspw. so aus: <br>
       MHSTKUIKTTHPQAZNVWQBJE5YQ2WACQQP <br>
-      Hier findest du <a style="color:white" href="https://github.com/TUfast-TUD/TUfast_TUD/blob/main/docs/2FA.md">mehr Informationen und eine vollständige Anleitung zur Einrichtung</a>.
+      Hier findest du <a
+        style="color:white"
+        href="https://github.com/TUfast-TUD/TUfast_TUD/blob/main/docs/2FA.md"
+      >mehr Informationen und eine vollständige Anleitung zur Einrichtung</a>.
     </p>
     <div class="form">
       <CustomInput


### PR DESCRIPTION
#### Description
The idp frontend HTML structure changed recently and broke the check for totp vs iotp.
This caused a failed totp insertion, resulting in an incomplete authentication.

#### Type of change
- [x] Bug fix (non-breaking change which fixes a bug)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that might cause existing functionality to not work as expected)

#### Further info
- [ ] This change requires a documentation update
- [ ] I updated the documentation accordingly, if required
- [ ] I commented my code where its useful

#### Testing
We have 1500+ Users. Please test your changes thoroughly.
- [x] Tested my changes on Firefox
- [ ] Tested my changes on Chromium-Based-Browsers
- [x] Successfully run `npm run test` locally

#### Additional Information
It seems to load the idp TOTP page twice.
The first time, the input field stays empty.
On the second load, the totp token gets inserted.
I don't know why this happens nor how to debug it.
