### PR TITLE
Add an option for jExam like styling in Selma

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -36,6 +36,7 @@ chrome.runtime.onInstalled.addListener(async (details) => {
         'theme',
         'studiengang',
         'hisqisPimpedTable',
+        'selmajExamTheme',
         'savedClickCounter',
         'saved_click_counter', // legacy
         'Rocket', // legacy
@@ -57,6 +58,7 @@ chrome.runtime.onInstalled.addListener(async (details) => {
       if (typeof currentSettings.dashboardDisplay === 'undefined') updateObj.dashboardDisplay = 'favoriten'
       if (typeof currentSettings.fwdEnabled === 'undefined') updateObj.fwdEnabled = true
       if (typeof currentSettings.hisqisPimpedTable === 'undefined') updateObj.hisqisPimpedTable = true
+      if (typeof currentSettings.selmajExamTheme === 'undefined') updateObj.selmajExamTheme = true
       if (typeof currentSettings.theme === 'undefined') updateObj.theme = 'system'
       if (typeof currentSettings.studiengang === 'undefined') updateObj.studiengang = 'general'
       if (typeof currentSettings.selectedRocketIcon === 'undefined') updateObj.selectedRocketIcon = JSON.stringify(rockets.default)

--- a/src/background.ts
+++ b/src/background.ts
@@ -21,7 +21,8 @@ chrome.runtime.onInstalled.addListener(async (details) => {
         theme: 'system',
         studiengang: 'general',
         hisqisPimpedTable: true,
-        bannersShown: ['mv3UpdateNotice']
+        bannersShown: ['mv3UpdateNotice'],
+        improveSelma: true,
       })
       await openSettingsPage('first_visit')
       break

--- a/src/background.ts
+++ b/src/background.ts
@@ -36,7 +36,7 @@ chrome.runtime.onInstalled.addListener(async (details) => {
         'theme',
         'studiengang',
         'hisqisPimpedTable',
-        'selmajExamTheme',
+        'improveSelma',
         'savedClickCounter',
         'saved_click_counter', // legacy
         'Rocket', // legacy
@@ -58,7 +58,7 @@ chrome.runtime.onInstalled.addListener(async (details) => {
       if (typeof currentSettings.dashboardDisplay === 'undefined') updateObj.dashboardDisplay = 'favoriten'
       if (typeof currentSettings.fwdEnabled === 'undefined') updateObj.fwdEnabled = true
       if (typeof currentSettings.hisqisPimpedTable === 'undefined') updateObj.hisqisPimpedTable = true
-      if (typeof currentSettings.selmajExamTheme === 'undefined') updateObj.selmajExamTheme = true
+      if (typeof currentSettings.improveSelma === 'undefined') updateObj.improveSelma = true
       if (typeof currentSettings.theme === 'undefined') updateObj.theme = 'system'
       if (typeof currentSettings.studiengang === 'undefined') updateObj.studiengang = 'general'
       if (typeof currentSettings.selectedRocketIcon === 'undefined') updateObj.selectedRocketIcon = JSON.stringify(rockets.default)

--- a/src/contentScripts/other/selma/layout.ts
+++ b/src/contentScripts/other/selma/layout.ts
@@ -155,8 +155,68 @@ if (currentView.startsWith("/APP/EXAMRESULTS/")) {
   // Remove the inline style that sets a width on the top right table cell
   const tableHeadRow = document.querySelector("thead>tr")!;
   tableHeadRow.children.item(3)!.removeAttribute("style");
-}
 
+  /*
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+*/
+} else if (currentView.startsWith("/APP/MYEXAMS/")) {
+  // Prüfungen
+
+  const body = document.querySelector("tbody")!;
+  const rows = [...body.children];
+  for (let i = 0; i < rows.length; i += 2) {
+    const topRow = rows[i];
+    const botRow = rows[i + 1];
+
+    const thElm = topRow.children.item(0)!;
+    thElm.className += " module-description";
+    const [moduleCode, hyperlink, _space, _br, description] = thElm.childNodes;
+
+    {
+      // Move exam type and examinant to the right side
+      thElm.setAttribute("colspan", "2");
+      const newSpacer = document.createElement("th");
+      newSpacer.setAttribute("colspan", "2");
+      newSpacer.replaceChildren(...botRow.children.item(1)!.children);
+      topRow.appendChild(newSpacer);
+    }
+
+    {
+      // Move the description under the exam title
+      // Remove useless first element
+      botRow.removeChild(botRow.children.item(1)!);
+      const newDescriptionElm = botRow.children.item(0)!;
+      newDescriptionElm.setAttribute("colspan", "2");
+      newDescriptionElm.className += " module-description";
+
+      // Some entries do not have a description
+      if (thElm.childNodes.length === 5) {
+        newDescriptionElm.appendChild(description);
+      }
+    }
+
+    // Table head "Prüfungsleistung"
+    document.querySelector("thead > tr > th#Name")!.textContent = "";
+    // Table head "Termin"
+    document.querySelector("thead > tr > th#Date")!.textContent =
+      "Prüfungsleistung/Termin";
+
+    console.log(thElm);
+  }
+}
 /*
 
 

--- a/src/contentScripts/other/selma/layout.ts
+++ b/src/contentScripts/other/selma/layout.ts
@@ -139,7 +139,10 @@ if (currentView.startsWith("/APP/EXAMRESULTS/")) {
         `;
       }
 
+      // Remove the inline vertical alignment
       elm.setAttribute("style", "vertical-align: middle;");
+
+      // Present the bar chart
       elm.innerHTML = `
         <svg
           viewBox="0 0 ${width} ${height}"
@@ -148,7 +151,21 @@ if (currentView.startsWith("/APP/EXAMRESULTS/")) {
         </svg>
       `;
 
+      // Insert placeholder element for proper spacing
+      // elm.parentElement!.append(document.createElement("td"));
+
       console.log(coarseValues);
     }
+
+    // Remove the inline style that sets a width on the top right table cell
+    const tableHeadRow = document.querySelector("thead>tr")!;
+
+    tableHeadRow.children.item(3)!.setAttribute("style", "");
+    // Add spacing element
+    /*
+    const spacer = document.createElement("th");
+    spacer.style.width = "2rem";
+    tableHeadRow.append(spacer);
+     */
   })();
 }

--- a/src/contentScripts/other/selma/layout.ts
+++ b/src/contentScripts/other/selma/layout.ts
@@ -1,416 +1,49 @@
-const currentView = document.location.pathname;
+const currentView = document.location.pathname
 // Regex for extracting Programm name and arguments from a popup Script
 // This is used to get the URL which would be opened in a popup
 const popupScriptsRegex =
-  /dl_popUp\("\/scripts\/mgrqispi\.dll\?APPNAME=CampusNet&PRGNAME=(\w+)&ARGUMENTS=([^"]+)"/;
+  /dl_popUp\("\/scripts\/mgrqispi\.dll\?APPNAME=CampusNet&PRGNAME=(\w+)&ARGUMENTS=([^"]+)"/
 
-function scriptToURL(script: string): string {
-  const matches = script.match(popupScriptsRegex)!;
+function scriptToURL (script: string): string {
+  const matches = script.match(popupScriptsRegex)!
 
-  const porgamName = matches.at(1)!;
-  const prgArguments = matches.at(2)!;
+  const porgamName = matches.at(1)!
+  const prgArguments = matches.at(2)!
 
-  return `https://selma.tu-dresden.de/APP/${porgamName}/${prgArguments}`;
+  return `https://selma.tu-dresden.de/APP/${porgamName}/${prgArguments}`
 }
 
-function mapGrade(gradeElm: Element) {
-  const grade = gradeElm.textContent!;
+function mapGrade (gradeElm: Element) {
+  const grade = gradeElm.textContent!
 
-  if (grade.includes("be")) {
-    gradeElm.textContent = "✔";
-    gradeElm.setAttribute("title", "Bestanden");
-  } else if (grade.includes("noch nicht gesetzt")) {
-    gradeElm.textContent = "🕓";
-    gradeElm.setAttribute("title", "Noch nicht gesetzt");
+  if (grade.includes('be')) {
+    gradeElm.textContent = '✔'
+    gradeElm.setAttribute('title', 'Bestanden')
+  } else if (grade.includes('noch nicht gesetzt')) {
+    gradeElm.textContent = '🕓'
+    gradeElm.setAttribute('title', 'Noch nicht gesetzt')
   }
 }
 
-function injectCSS(filename: string) {
-  const style = document.createElement("link");
-  style.rel = "stylesheet";
-  style.type = "text/css";
+function injectCSS (filename: string) {
+  const style = document.createElement('link')
+  style.rel = 'stylesheet'
+  style.type = 'text/css'
   style.href = chrome.runtime.getURL(
-    `styles/contentScripts/selma/${filename}.css`,
+    `styles/contentScripts/selma/${filename}.css`
   );
 
   (document.head || document.body || document.documentElement).appendChild(
-    style,
-  );
+    style
+  )
 }
 
 /*
-
-
-
-
-
-
-
-
-
-
-*/
-
-(async () => {
-  const { selmajExamTheme } = await chrome.storage.local.get([
-    "selmajExamTheme",
-  ]);
-
-  if (!selmajExamTheme) return;
-
-  // Apply all custom changes
-  document.addEventListener("DOMContentLoaded", eventListener, false);
-})();
-
-function eventListener() {
-  document.removeEventListener("DOMContentLoaded", eventListener, false);
-
-  // Inject css
-  injectCSS("base");
-  if (
-    currentView.startsWith("/APP/EXAMRESULTS/") ||
-    currentView.startsWith("/APP/COURSERESULTS/")
-  ) {
-    injectCSS("exam_results");
-  }
-  if (currentView.startsWith("/APP/MYEXAMS/")) {
-    injectCSS("my_exams");
-  }
-
-  applyChanges();
-}
-
-function applyChanges() {
-  if (currentView.startsWith("/APP/EXAMRESULTS/")) {
-    // Prüfungen > Ergebnisse
-
-    // Remove the "gut/befriedigend" section
-    const headRow = document.querySelector("thead>tr")!;
-    headRow.removeChild(headRow.children.item(3)!);
-    headRow.children.item(3)!.textContent = "Notenverteilung";
-
-    const body = document.querySelector("tbody")!;
-    const promises: Promise<{ doc: Document; elm: Element; url: string }>[] =
-      [];
-    for (const row of body.children) {
-      // Remove useless inline styles which set the vertical alignment
-      for (const col of row.children) col.removeAttribute("style");
-
-      row.removeChild(row.children.item(3)!);
-
-      // Extract script content
-      const lastCol = row.children.item(3)!;
-      const scriptElm = lastCol.children.item(1);
-      if (scriptElm === null) continue;
-
-      const scriptContent = scriptElm!.innerHTML;
-
-      const url = scriptToURL(scriptContent);
-
-      promises.push(
-        fetch(url).then(async (s) => {
-          const parser = new DOMParser();
-          const doc = parser.parseFromString(await s.text(), "text/html");
-
-          return { doc, elm: lastCol, url };
-        }),
-      );
-    }
-
-    promises.forEach((p) =>
-      p.then(({ doc, elm, url }) => {
-        const tableBody = doc.querySelector("tbody")!;
-        const values = [...tableBody.children].map((tr) => {
-          const gradeText = tr.children.item(0)!.textContent!.replace(",", ".");
-          const grade = parseFloat(gradeText);
-
-          const countText = tr.children.item(1)!.textContent!;
-          let count: number;
-          if (countText === "---") count = 0;
-          else count = parseInt(countText);
-
-          return {
-            grade,
-            count,
-          };
-        });
-        // .slice(0, -2); // Remove the 5.0 from all lists
-
-        // Present the bar chart
-        const graphSVG = Graphing.createSVGGradeDistributionGraph(values, url);
-        elm.innerHTML = graphSVG;
-      }),
-    );
-
-    // Remove the inline style that sets a width on the top right table cell
-    const tableHeadRow = document.querySelector("thead>tr")!;
-    tableHeadRow.children.item(3)!.removeAttribute("style");
-    /*
-
-
-
-
-
-
-
-
-*/
-  } else if (currentView.startsWith("/APP/COURSERESULTS/")) {
-    // Prüfungen > Ergebnisse
-
-    // Remove the "bestanden" section
-    const headRow = document.querySelector("thead>tr")!;
-    headRow.removeChild(headRow.children.item(3)!);
-
-    // Add "Notenverteilung" header
-    {
-      headRow.children.item(3)!.removeAttribute("colspan");
-      const newHeader = document.createElement("th");
-      newHeader.textContent = "Notenverteilung";
-      headRow.appendChild(newHeader);
-    }
-
-    // Create the grade distribution graph
-    const body = document.querySelector("tbody")!;
-    const promises: Promise<{ doc: Document; elm: Element; url: string }>[] =
-      [];
-    for (const row of body.children) {
-      // Remove useless inline styles which set the vertical alignment
-      for (const col of row.children) col.removeAttribute("style");
-
-      // Remove "Status" column
-      row.removeChild(row.children.item(3)!);
-
-      {
-        // Map grade descriptions to emojis
-        const gradeElm = row.children.item(2)!;
-        mapGrade(gradeElm);
-      }
-
-      // Extract script content
-      const lastCol = row.children.item(4)!;
-      const scriptElm = lastCol.children.item(1);
-      // Skip courses wihtout grades
-      if (scriptElm === null) continue;
-
-      const scriptContent = scriptElm!.innerHTML;
-
-      const url = scriptToURL(scriptContent);
-
-      promises.push(
-        fetch(url).then(async (s) => {
-          const parser = new DOMParser();
-          const doc = parser.parseFromString(await s.text(), "text/html");
-
-          return { doc, elm: lastCol, url };
-        }),
-      );
-    }
-
-    promises.forEach((p) =>
-      p.then(({ doc, elm, url }) => {
-        // Parse the grade distributions
-        const tableBody = doc.querySelector("tbody")!;
-        const values = [...tableBody.children].map((tr) => {
-          const gradeText = tr.children.item(0)!.textContent!.replace(",", ".");
-          const grade = parseFloat(gradeText);
-
-          const countText = tr.children.item(1)!.textContent!;
-          let count: number;
-          if (countText === "---") count = 0;
-          else count = parseInt(countText);
-
-          return {
-            grade,
-            count,
-          };
-        });
-        // .slice(0, -2); // Remove the 5.0 from all lists
-
-        // Present the bar chart
-        const graphSVG = Graphing.createSVGGradeDistributionGraph(values, url);
-        elm.innerHTML = graphSVG;
-      }),
-    );
-
-    // Remove the inline style that sets a width on the top right table cell
-    const tableHeadRow = document.querySelector("thead>tr")!;
-    tableHeadRow.children.item(3)!.removeAttribute("style");
-
-    // Draw try counter in the jExam style
-    for (const row of body.children) {
-      const linkElm = row.children.item(3)!;
-      const scriptElm = linkElm.children.item(1);
-      // Skip courses wihtout grades
-      if (scriptElm === null) continue;
-
-      // Extract script content
-      const scriptContent = scriptElm!.innerHTML;
-      const url = scriptToURL(scriptContent);
-
-      // Center the remaining "> Prüfung" links so it looks better after everything loaded
-      linkElm.setAttribute("style", "text-align: center;");
-
-      // Fetch data
-      fetch(url).then(async (s) => {
-        const parser = new DOMParser();
-        const doc = parser.parseFromString(await s.text(), "text/html");
-
-        // Extracting the grades of individual tries
-        const tableBody = doc.querySelector("tbody")!;
-        const tries: Graphing.Try[] = [];
-
-        // Search for tries
-        for (let i = 0; i < tableBody.children.length; i++) {
-          const trElm = tableBody.children.item(i)!;
-          const firstTd = trElm.querySelector("td.level02");
-
-          // Before a row with a grade there is always a row containing "Modulprüfung"
-          if (firstTd !== null && firstTd.textContent === "Modulprüfung") {
-            // Next row will contain a try with a grade
-            let nextTrElm = tableBody.children.item(i + 1)!;
-            // Sometimes there is an extra row
-            if (nextTrElm.children.length === 1) {
-              nextTrElm = tableBody.children.item(i + 2)!;
-            }
-
-            // Extract information
-            const date = nextTrElm.children.item(2)!.textContent!.trim();
-            const grade = nextTrElm.children.item(3)!.textContent!.trim();
-            tries.push({ date, grade });
-
-            i += 2;
-            continue;
-          }
-        }
-
-        // Unable to parse the grades from the tables
-        if (tries.length === 0) return;
-
-        // Replace link with a chart
-        linkElm.innerHTML = Graphing.createJExamTryCounter(tries, url);
-      });
-    }
-
-    /*
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-*/
-  } else if (currentView.startsWith("/APP/MYEXAMS/")) {
-    // Prüfungen
-
-    const body = document.querySelector("tbody")!;
-    const rows = [...body.children];
-    for (let i = 0; i < rows.length; i += 2) {
-      const topRow = rows[i];
-      const botRow = rows[i + 1];
-
-      const thElm = topRow.children.item(0)!;
-      thElm.className += " module-description";
-      const [moduleCode, hyperlink, _space, _br, description] =
-        thElm.childNodes;
-
-      {
-        // Move exam type and examinant to the right side
-        thElm.setAttribute("colspan", "2");
-        const newSpacer = document.createElement("th");
-        newSpacer.setAttribute("colspan", "2");
-        newSpacer.replaceChildren(...botRow.children.item(1)!.children);
-        topRow.appendChild(newSpacer);
-      }
-
-      {
-        // Move the description under the exam title
-        // Remove useless first element
-        botRow.removeChild(botRow.children.item(1)!);
-        const newDescriptionElm = botRow.children.item(0)!;
-        newDescriptionElm.setAttribute("colspan", "2");
-        newDescriptionElm.className += " module-description";
-
-        // Some entries do not have a description
-        if (thElm.childNodes.length === 5) {
-          newDescriptionElm.appendChild(description);
-        }
-      }
-
-      {
-        // Remove useless timespans
-        const dateElm = botRow.children.item(1)!;
-        dateElm.textContent = dateElm.textContent!.replaceAll(
-          "00:00-00:00",
-          "",
-        );
-      }
-
-      // Table head "Prüfungsleistung"
-      document.querySelector("thead > tr > th#Name")!.textContent = "";
-      // Table head "Termin"
-      document.querySelector("thead > tr > th#Date")!.textContent =
-        "Prüfungsleistung/Termin";
-    }
-  }
-}
-
-/*
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+---
 
 Proabably a proper bundler config would be better
 
+---
 */
 
 namespace Graphing {
@@ -419,70 +52,59 @@ namespace Graphing {
     count: number;
   };
 
-  function maxGradeCount(values: GradeStat[]): number {
-    let max = 0;
+  function maxGradeCount (values: GradeStat[]): number {
+    let max = 0
     for (const { count } of values) {
-      if (count > max) max = count;
+      if (count > max) max = count
     }
-    return max;
-  }
-
-  function totalGradeCount(values: GradeStat[]): number {
-    return values.map(({ grade, count }) => count).reduce((p, c) => p + c);
-  }
-
-  function calculateAverage(values: GradeStat[]): number {
-    return (
-      values.map(({ grade, count }) => grade * count).reduce((p, c) => p + c) /
-      totalGradeCount(values)
-    );
+    return max
   }
 
   // Reduce the grade increments
-  function pickGradeSubset(values: GradeStat[]): GradeStat[] {
-    const increments = [1, 1.3, 1.7, 2, 2.3, 2.7, 3, 3.3, 3.7, 4, 5];
+  function pickGradeSubset (values: GradeStat[]): GradeStat[] {
+    const increments = [1, 1.3, 1.7, 2, 2.3, 2.7, 3, 3.3, 3.7, 4, 5]
 
     const newValues = increments.map((inc) => ({
       grade: inc,
-      count: 0,
-    }));
+      count: 0
+    }))
 
-    let currentIncIndex = 0;
+    let currentIncIndex = 0
     for (const { grade, count } of values) {
       // Skip to next increment if we reached it's lower end
       if (currentIncIndex !== increments.length - 1) {
-        const nextIncrement = increments[currentIncIndex + 1];
-        if (grade >= nextIncrement) currentIncIndex++;
+        const nextIncrement = increments[currentIncIndex + 1]
+        if (grade >= nextIncrement) currentIncIndex++
       }
-      newValues[currentIncIndex].count += count;
+      newValues[currentIncIndex].count += count
     }
 
-    return newValues;
+    return newValues
   }
 
-  export function createSVGGradeDistributionGraph(
+  export function createSVGGradeDistributionGraph (
     values: GradeStat[],
     url: string,
     width = 200,
-    height = 100,
+    height = 100
   ): string {
     // Reduce the bar count / pick bigger intervals
-    const coarseValues = pickGradeSubset(values);
+    const coarseValues = pickGradeSubset(values)
 
     // Spacing in percent of bar width
-    const spacing = 0.1;
-    const barWidth = (width * (1 - spacing)) / coarseValues.length;
+    const spacing = 0.1
+    const barWidth = (width * (1 - spacing)) / coarseValues.length
 
     // Drawing the Chart
-    let barsSvg = "";
-    const maxCount = maxGradeCount(coarseValues);
+    let barsSvg = ''
+    const maxCount = maxGradeCount(coarseValues)
     for (let x = 0; x < coarseValues.length; x++) {
-      const { grade, count } = coarseValues[x];
-      const barHeight = (count / maxCount) * height;
+      const { grade, count } = coarseValues[x]
+      const barHeight = (count / maxCount) * height
 
       // Allows styling the failed sections differently
-      let className = "passed";
-      if (grade >= 5.0) className = "failed";
+      let className = 'passed'
+      if (grade >= 5.0) className = 'failed'
 
       barsSvg += `
             <rect
@@ -493,7 +115,7 @@ namespace Graphing {
             >
               <title>${grade.toFixed(2)}</title>
             </rect>
-          `;
+          `
     }
 
     return `
@@ -511,38 +133,38 @@ namespace Graphing {
           ${barsSvg}
         </a>
       </svg>
-    `;
+    `
   }
 
   export type Try = { date: string; grade: string };
 
-  export function createJExamTryCounter(
+  export function createJExamTryCounter (
     tries: Try[],
     url: string,
-    width = 200,
+    width = 200
   ): string {
     // Spacing in percent of circle width
-    const spacing = 0.2;
+    const spacing = 0.2
     // Stroke width in percent of radius
-    const strokeWidth = 0.12;
+    const strokeWidth = 0.12
 
-    const filledRadius = (width * (1 - spacing)) / 6;
-    const strokedRadius = filledRadius * (1 - strokeWidth);
+    const filledRadius = (width * (1 - spacing)) / 6
+    const strokedRadius = filledRadius * (1 - strokeWidth)
     // +1 to prevent weird cut off
-    const height = Math.ceil(2 * filledRadius) + 1;
+    const height = Math.ceil(2 * filledRadius) + 1
 
     // Drawing the Chart
-    let svgContent = "";
+    let svgContent = ''
 
     for (let x = 0; x < 3; x++) {
-      let className = "used";
-      let tooltip = "";
+      let className = 'used'
+      let tooltip = ''
       if (x >= tries.length) {
         // Mark open try
-        className = "open";
+        className = 'open'
       } else {
-        const { date, grade } = tries[x];
-        tooltip = `<title>${grade}\n${date}</title>`;
+        const { date, grade } = tries[x]
+        tooltip = `<title>${grade}\n${date}</title>`
       }
 
       svgContent += `
@@ -551,11 +173,11 @@ namespace Graphing {
               stroke-width="${strokeWidth * height}"
               cx="${2 * x * filledRadius * (1 + spacing) + filledRadius}"
               cy="${filledRadius}"
-              r="${className === "used" ? filledRadius : strokedRadius}"
+              r="${className === 'used' ? filledRadius : strokedRadius}"
             >
               ${tooltip}
             </circle>
-          `;
+          `
     }
 
     return `
@@ -573,6 +195,306 @@ namespace Graphing {
           ${svgContent}
         </a>
       </svg>
-    `;
+    `
+  }
+}
+
+/*
+---
+
+Actual logic
+
+---
+*/
+
+(async () => {
+  const { selmajExamTheme } = await chrome.storage.local.get([
+    'selmajExamTheme'
+  ])
+
+  if (!selmajExamTheme) return
+
+  // Apply all custom changes
+  document.addEventListener('DOMContentLoaded', eventListener, false)
+})()
+
+function eventListener () {
+  document.removeEventListener('DOMContentLoaded', eventListener, false)
+
+  // Inject css
+  injectCSS('base')
+  if (
+    currentView.startsWith('/APP/EXAMRESULTS/') ||
+    currentView.startsWith('/APP/COURSERESULTS/')
+  ) {
+    injectCSS('exam_results')
+  }
+  if (currentView.startsWith('/APP/MYEXAMS/')) {
+    injectCSS('my_exams')
+  }
+
+  applyChanges()
+}
+
+function applyChanges () {
+  if (currentView.startsWith('/APP/EXAMRESULTS/')) {
+    // Prüfungen > Ergebnisse
+
+    // Remove the "gut/befriedigend" section
+    const headRow = document.querySelector('thead>tr')!
+    headRow.removeChild(headRow.children.item(3)!)
+    headRow.children.item(3)!.textContent = 'Notenverteilung'
+
+    const body = document.querySelector('tbody')!
+    const promises: Promise<{ doc: Document; elm: Element; url: string }>[] =
+      []
+    for (const row of body.children) {
+      // Remove useless inline styles which set the vertical alignment
+      for (const col of row.children) col.removeAttribute('style')
+
+      row.removeChild(row.children.item(3)!)
+
+      // Extract script content
+      const lastCol = row.children.item(3)!
+      const scriptElm = lastCol.children.item(1)
+      if (scriptElm === null) continue
+
+      const scriptContent = scriptElm!.innerHTML
+
+      const url = scriptToURL(scriptContent)
+
+      promises.push(
+        fetch(url).then(async (s) => {
+          const parser = new DOMParser()
+          const doc = parser.parseFromString(await s.text(), 'text/html')
+
+          return { doc, elm: lastCol, url }
+        })
+      )
+    }
+
+    promises.forEach((p) =>
+      p.then(({ doc, elm, url }) => {
+        const tableBody = doc.querySelector('tbody')!
+        const values = [...tableBody.children].map((tr) => {
+          const gradeText = tr.children.item(0)!.textContent!.replace(',', '.')
+          const grade = parseFloat(gradeText)
+
+          const countText = tr.children.item(1)!.textContent!
+          let count: number
+          if (countText === '---') count = 0
+          else count = parseInt(countText)
+
+          return {
+            grade,
+            count
+          }
+        })
+        // .slice(0, -2); // Remove the 5.0 from all lists
+
+        // Present the bar chart
+        const graphSVG = Graphing.createSVGGradeDistributionGraph(values, url)
+        elm.innerHTML = graphSVG
+      })
+    )
+
+    // Remove the inline style that sets a width on the top right table cell
+    const tableHeadRow = document.querySelector('thead>tr')!
+    tableHeadRow.children.item(3)!.removeAttribute('style')
+    /*
+
+*/
+  } else if (currentView.startsWith('/APP/COURSERESULTS/')) {
+    // Prüfungen > Ergebnisse
+
+    // Remove the "bestanden" section
+    const headRow = document.querySelector('thead>tr')!
+    headRow.removeChild(headRow.children.item(3)!)
+
+    // Add "Notenverteilung" header
+    {
+      headRow.children.item(3)!.removeAttribute('colspan')
+      const newHeader = document.createElement('th')
+      newHeader.textContent = 'Notenverteilung'
+      headRow.appendChild(newHeader)
+    }
+
+    // Create the grade distribution graph
+    const body = document.querySelector('tbody')!
+    const promises: Promise<{ doc: Document; elm: Element; url: string }>[] =
+      []
+    for (const row of body.children) {
+      // Remove useless inline styles which set the vertical alignment
+      for (const col of row.children) col.removeAttribute('style')
+
+      // Remove "Status" column
+      row.removeChild(row.children.item(3)!)
+
+      {
+        // Map grade descriptions to emojis
+        const gradeElm = row.children.item(2)!
+        mapGrade(gradeElm)
+      }
+
+      // Extract script content
+      const lastCol = row.children.item(4)!
+      const scriptElm = lastCol.children.item(1)
+      // Skip courses wihtout grades
+      if (scriptElm === null) continue
+
+      const scriptContent = scriptElm!.innerHTML
+
+      const url = scriptToURL(scriptContent)
+
+      promises.push(
+        fetch(url).then(async (s) => {
+          const parser = new DOMParser()
+          const doc = parser.parseFromString(await s.text(), 'text/html')
+
+          return { doc, elm: lastCol, url }
+        })
+      )
+    }
+
+    promises.forEach((p) =>
+      p.then(({ doc, elm, url }) => {
+        // Parse the grade distributions
+        const tableBody = doc.querySelector('tbody')!
+        const values = [...tableBody.children].map((tr) => {
+          const gradeText = tr.children.item(0)!.textContent!.replace(',', '.')
+          const grade = parseFloat(gradeText)
+
+          const countText = tr.children.item(1)!.textContent!
+          let count: number
+          if (countText === '---') count = 0
+          else count = parseInt(countText)
+
+          return {
+            grade,
+            count
+          }
+        })
+        // .slice(0, -2); // Remove the 5.0 from all lists
+
+        // Present the bar chart
+        const graphSVG = Graphing.createSVGGradeDistributionGraph(values, url)
+        elm.innerHTML = graphSVG
+      })
+    )
+
+    // Remove the inline style that sets a width on the top right table cell
+    const tableHeadRow = document.querySelector('thead>tr')!
+    tableHeadRow.children.item(3)!.removeAttribute('style')
+
+    // Draw try counter in the jExam style
+    for (const row of body.children) {
+      const linkElm = row.children.item(3)!
+      const scriptElm = linkElm.children.item(1)
+      // Skip courses wihtout grades
+      if (scriptElm === null) continue
+
+      // Extract script content
+      const scriptContent = scriptElm!.innerHTML
+      const url = scriptToURL(scriptContent)
+
+      // Center the remaining "> Prüfung" links so it looks better after everything loaded
+      linkElm.setAttribute('style', 'text-align: center;')
+
+      // Fetch data
+      fetch(url).then(async (s) => {
+        const parser = new DOMParser()
+        const doc = parser.parseFromString(await s.text(), 'text/html')
+
+        // Extracting the grades of individual tries
+        const tableBody = doc.querySelector('tbody')!
+        const tries: Graphing.Try[] = []
+
+        // Search for tries
+        for (let i = 0; i < tableBody.children.length; i++) {
+          const trElm = tableBody.children.item(i)!
+          const firstTd = trElm.querySelector('td.level02')
+
+          // Before a row with a grade there is always a row containing "Modulprüfung"
+          if (firstTd !== null && firstTd.textContent === 'Modulprüfung') {
+            // Next row will contain a try with a grade
+            let nextTrElm = tableBody.children.item(i + 1)!
+            // Sometimes there is an extra row
+            if (nextTrElm.children.length === 1) {
+              nextTrElm = tableBody.children.item(i + 2)!
+            }
+
+            // Extract information
+            const date = nextTrElm.children.item(2)!.textContent!.trim()
+            const grade = nextTrElm.children.item(3)!.textContent!.trim()
+            tries.push({ date, grade })
+
+            i += 2
+            continue
+          }
+        }
+
+        // Unable to parse the grades from the tables
+        if (tries.length === 0) return
+
+        // Replace link with a chart
+        linkElm.innerHTML = Graphing.createJExamTryCounter(tries, url)
+      })
+    }
+
+    /*
+
+*/
+  } else if (currentView.startsWith('/APP/MYEXAMS/')) {
+    // Prüfungen
+
+    const body = document.querySelector('tbody')!
+    const rows = [...body.children]
+    for (let i = 0; i < rows.length; i += 2) {
+      const topRow = rows[i]
+      const botRow = rows[i + 1]
+
+      const thElm = topRow.children.item(0)!
+      thElm.className += ' module-description'
+      // moduleCode, hyperlink, space, br, description
+      const [, , , , description] = thElm.childNodes
+
+      {
+        // Move exam type and examinant to the right side
+        thElm.setAttribute('colspan', '2')
+        const newSpacer = document.createElement('th')
+        newSpacer.setAttribute('colspan', '2')
+        newSpacer.replaceChildren(...botRow.children.item(1)!.children)
+        topRow.appendChild(newSpacer)
+      }
+
+      {
+        // Move the description under the exam title
+        // Remove useless first element
+        botRow.removeChild(botRow.children.item(1)!)
+        const newDescriptionElm = botRow.children.item(0)!
+        newDescriptionElm.setAttribute('colspan', '2')
+        newDescriptionElm.className += ' module-description'
+
+        // Some entries do not have a description
+        if (thElm.childNodes.length === 5) {
+          newDescriptionElm.appendChild(description)
+        }
+      }
+
+      {
+        // Remove useless timespans
+        const dateElm = botRow.children.item(1)!
+        dateElm.textContent = dateElm.textContent!.replaceAll(
+          '00:00-00:00',
+          ''
+        )
+      }
+
+      // Table head "Prüfungsleistung"
+      document.querySelector('thead > tr > th#Name')!.textContent = ''
+      // Table head "Termin"
+      document.querySelector('thead > tr > th#Date')!.textContent =
+        'Prüfungsleistung/Termin'
+    }
   }
 }

--- a/src/contentScripts/other/selma/layout.ts
+++ b/src/contentScripts/other/selma/layout.ts
@@ -13,52 +13,6 @@ function scriptToURL(script: string): string {
   return `https://selma.tu-dresden.de/APP/${porgamName}/${prgArguments}`;
 }
 
-type GradeStat = {
-  grade: number;
-  count: number;
-};
-
-function maxGradeCount(values: GradeStat[]): number {
-  let max = 0;
-  for (const { grade, count } of values) {
-    if (count > max) max = count;
-  }
-  return max;
-}
-
-function totalGradeCount(values: GradeStat[]): number {
-  return values.map(({ grade, count }) => count).reduce((p, c) => p + c);
-}
-
-function calculateAverage(values: GradeStat[]): number {
-  return (
-    values.map(({ grade, count }) => grade * count).reduce((p, c) => p + c) /
-    totalGradeCount(values)
-  );
-}
-
-// Reduce the grade increments
-function pickGradeSubset(values: GradeStat[]): GradeStat[] {
-  const increments = [1, 1.3, 1.7, 2, 2.3, 2.7, 3, 3.3, 3.7, 4];
-
-  const newValues = increments.map((inc) => ({
-    grade: inc,
-    count: 0,
-  }));
-
-  let currentIncIndex = 0;
-  for (const { grade, count } of values) {
-    // Skip to next increment if we reached it's lower end
-    if (currentIncIndex !== increments.length - 1) {
-      const nextIncrement = increments[currentIncIndex + 1];
-      if (grade >= nextIncrement) currentIncIndex++;
-    }
-    newValues[currentIncIndex].count += count;
-  }
-
-  return newValues;
-}
-
 if (currentView.startsWith("/APP/EXAMRESULTS/")) {
   // Prüfungen > Ergebnisse
 
@@ -69,6 +23,9 @@ if (currentView.startsWith("/APP/EXAMRESULTS/")) {
   const body = document.querySelector("tbody")!;
   const promises: Promise<{ doc: Document; elm: Element }>[] = [];
   for (const row of body.children) {
+    // Remove useless inline styles which set the vertical alignment
+    for (const col of row.children) col.removeAttribute("style");
+
     row.removeChild(row.children.item(3)!);
 
     const lastCol = row.children.item(3)!;
@@ -90,82 +47,184 @@ if (currentView.startsWith("/APP/EXAMRESULTS/")) {
     const gradeOverviews = await Promise.all(promises);
 
     for (let i = 0; i < gradeOverviews.length; i++) {
+      // Parse the grade distributions
       const { doc, elm } = gradeOverviews[i];
       const tableBody = doc.querySelector("tbody")!;
-      const values = [...tableBody.children]
-        .map((tr) => {
-          const gradeText = tr.children.item(0)!.textContent!.replace(",", ".");
-          const grade = parseFloat(gradeText);
+      const values = [...tableBody.children].map((tr) => {
+        const gradeText = tr.children.item(0)!.textContent!.replace(",", ".");
+        const grade = parseFloat(gradeText);
 
-          const countText = tr.children.item(1)!.textContent!;
-          let count: number;
-          if (countText === "---") {
-            count = 0;
-          } else {
-            count = parseInt(countText);
-          }
+        const countText = tr.children.item(1)!.textContent!;
+        let count: number;
+        if (countText === "---") count = 0;
+        else count = parseInt(countText);
 
-          return {
-            grade,
-            count,
-          };
-        })
-        .slice(0, -2); // Remove the 5.0 from all lists
-
-      // Avg
-      const avg = calculateAverage(values);
-      elm.innerHTML = `avg: ${avg.toFixed(2)}`;
-
-      // Drawing the Chart
-      const coarseValues = pickGradeSubset(values);
-
-      const width = 200;
-      const spacing = 0.1;
-      const barWidth = (width * (1 - spacing)) / coarseValues.length;
-      const height = 100;
-
-      let barsSvg = "";
-      const maxCount = maxGradeCount(coarseValues);
-      for (let x = 0; x < coarseValues.length; x++) {
-        const { grade, count } = coarseValues[x];
-        const barHeight = (count / maxCount) * height;
-
-        barsSvg += `
-        <rect
-          x="${x * barWidth * (1 + spacing)}" y="${height - barHeight}"
-          width="${barWidth}" height="${barHeight}"
-          rx="5" ry="5"
-        />
-        `;
-      }
-
-      // Remove the inline vertical alignment
-      elm.setAttribute("style", "vertical-align: middle;");
+        return {
+          grade,
+          count,
+        };
+      });
+      // .slice(0, -2); // Remove the 5.0 from all lists
 
       // Present the bar chart
-      elm.innerHTML = `
-        <svg
-          viewBox="0 0 ${width} ${height}"
-          xmlns="http://www.w3.org/2000/svg">
-          ${barsSvg}
-        </svg>
-      `;
-
-      // Insert placeholder element for proper spacing
-      // elm.parentElement!.append(document.createElement("td"));
-
-      console.log(coarseValues);
+      const graphSVG = Graphing.createSVGGradeDistributionGraph(values);
+      elm.innerHTML = graphSVG;
     }
 
     // Remove the inline style that sets a width on the top right table cell
     const tableHeadRow = document.querySelector("thead>tr")!;
-
-    tableHeadRow.children.item(3)!.setAttribute("style", "");
-    // Add spacing element
-    /*
-    const spacer = document.createElement("th");
-    spacer.style.width = "2rem";
-    tableHeadRow.append(spacer);
-     */
+    tableHeadRow.children.item(3)!.removeAttribute("style");
   })();
+}
+
+/*
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Proabably a proper bundler config would be better
+
+*/
+
+namespace Graphing {
+  type GradeStat = {
+    grade: number;
+    count: number;
+  };
+
+  function maxGradeCount(values: GradeStat[]): number {
+    let max = 0;
+    for (const { count } of values) {
+      if (count > max) max = count;
+    }
+    return max;
+  }
+
+  function totalGradeCount(values: GradeStat[]): number {
+    return values.map(({ grade, count }) => count).reduce((p, c) => p + c);
+  }
+
+  function calculateAverage(values: GradeStat[]): number {
+    return (
+      values.map(({ grade, count }) => grade * count).reduce((p, c) => p + c) /
+      totalGradeCount(values)
+    );
+  }
+
+  // Reduce the grade increments
+  function pickGradeSubset(values: GradeStat[]): GradeStat[] {
+    const increments = [1, 1.3, 1.7, 2, 2.3, 2.7, 3, 3.3, 3.7, 4, 5];
+
+    const newValues = increments.map((inc) => ({
+      grade: inc,
+      count: 0,
+    }));
+
+    let currentIncIndex = 0;
+    for (const { grade, count } of values) {
+      // Skip to next increment if we reached it's lower end
+      if (currentIncIndex !== increments.length - 1) {
+        const nextIncrement = increments[currentIncIndex + 1];
+        if (grade >= nextIncrement) currentIncIndex++;
+      }
+      newValues[currentIncIndex].count += count;
+    }
+
+    return newValues;
+  }
+
+  export function createSVGGradeDistributionGraph(
+    values: GradeStat[],
+    width = 200,
+    height = 100,
+  ): string {
+    // Reduce the bar count / pick bigger intervals
+    const coarseValues = pickGradeSubset(values);
+
+    // Spacing in percent of bar width
+    const spacing = 0.1;
+    const barWidth = (width * (1 - spacing)) / coarseValues.length;
+
+    // Drawing the Chart
+    let barsSvg = "";
+    const maxCount = maxGradeCount(coarseValues);
+    for (let x = 0; x < coarseValues.length - 1; x++) {
+      const { count } = coarseValues[x];
+      const barHeight = (count / maxCount) * height;
+
+      barsSvg += `
+            <rect
+              class="passed"
+              x="${x * barWidth * (1 + spacing)}" y="${height - barHeight}"
+              width="${barWidth}" height="${barHeight}"
+              rx="5" ry="5"
+            />
+          `;
+    }
+
+    // Color the last rect for 5.0 / failed differently
+    {
+      const x = coarseValues.length - 1;
+      const { count } = coarseValues[x];
+      const barHeight = (count / maxCount) * height;
+
+      barsSvg += `
+            <rect
+              class="failed"
+              x="${x * barWidth * (1 + spacing)}" y="${height - barHeight}"
+              width="${barWidth}" height="${barHeight}"
+              rx="5" ry="5"
+            />
+        `;
+    }
+
+    return `
+      <svg
+        viewBox="0 0 ${width} ${height}"
+        xmlns="http://www.w3.org/2000/svg">
+        ${barsSvg}
+      </svg>
+    `;
+  }
 }

--- a/src/contentScripts/other/selma/layout.ts
+++ b/src/contentScripts/other/selma/layout.ts
@@ -207,19 +207,60 @@ Actual logic
 ---
 */
 
+// Create a small banner that indicates the user that the site was modified
+// It also adds a small toggle to disable the table
+function createCreditsBanner () {
+  const imgUrl = chrome.runtime.getURL('/assets/images/tufast48.png')
+  const credits = document.createElement('p')
+
+  credits.style.margin = 'auto'
+  credits.style.marginRight = '0'
+  credits.style.color = '#002557' // Selma theme color
+  credits.id = 'TUfastCredits'
+  credits.innerHTML = `Table powered by
+    <img src="${imgUrl}" style="position:relative; right: 2px; height: 0.7lh; top: 0.15lh; padding-left: 0.1lh;">
+    <a href="https://www.tu-fast.de" target="_blank">TUfast</a>
+    by <a href="https://github.com/A-K-O-R-A" target="_blank">AKORA</a>
+    `
+
+  const disableButton = document.createElement('button')
+  // Similiar style to logout button
+  disableButton.setAttribute(
+    'style',
+    `
+    border: 1px solid rgb(255, 255, 255);
+    color: rgb(221, 39, 39);
+    text-decoration: none;
+    padding: 0.5rem 1rem;
+    margin: 0 1rem;
+    border-radius: 0px;
+    `
+  )
+
+  // Tooltip
+  disableButton.title =
+    'Disable the "ImproveSelma" feature and reload the page to apply the change.'
+  disableButton.textContent = 'Disable'
+  disableButton.onclick = async (event) => {
+    event.preventDefault()
+    await chrome.storage.local.set({ improveSelma: false })
+  }
+  credits.appendChild(disableButton)
+
+  return credits
+}
+
 (async () => {
-  const { improveSelma } = await chrome.storage.local.get([
-    'improveSelma'
-  ])
+  const { improveSelma } = await chrome.storage.local.get(['improveSelma'])
 
   if (!improveSelma) return
 
   // Apply all custom changes
-  document.addEventListener('DOMContentLoaded', eventListener, false)
+  document.addEventListener('DOMContentLoaded', eventListener)
 })()
 
 function eventListener () {
-  document.removeEventListener('DOMContentLoaded', eventListener, false)
+  document.removeEventListener('DOMContentLoaded', eventListener)
 
   // Inject css
   injectCSS('base')
@@ -231,6 +272,12 @@ function eventListener () {
   }
   if (currentView.startsWith('/APP/MYEXAMS/')) {
     injectCSS('my_exams')
+  }
+
+  // Add Credit banner
+  {
+    const creditElm = createCreditsBanner()
+    document.querySelector('.semesterChoice')!.appendChild(creditElm)
   }
 
   applyChanges()

--- a/src/contentScripts/other/selma/layout.ts
+++ b/src/contentScripts/other/selma/layout.ts
@@ -208,11 +208,11 @@ Actual logic
 */
 
 (async () => {
-  const { selmajExamTheme } = await chrome.storage.local.get([
-    'selmajExamTheme'
+  const { improveSelma } = await chrome.storage.local.get([
+    'improveSelma'
   ])
 
-  if (!selmajExamTheme) return
+  if (!improveSelma) return
 
   // Apply all custom changes
   document.addEventListener('DOMContentLoaded', eventListener, false)

--- a/src/contentScripts/other/selma/layout.ts
+++ b/src/contentScripts/other/selma/layout.ts
@@ -21,7 +21,7 @@ if (currentView.startsWith("/APP/EXAMRESULTS/")) {
   headRow.removeChild(headRow.children.item(3)!);
 
   const body = document.querySelector("tbody")!;
-  const promises: Promise<{ doc: Document; elm: Element }>[] = [];
+  const promises: Promise<{ doc: Document; elm: Element; url: string }>[] = [];
   for (const row of body.children) {
     // Remove useless inline styles which set the vertical alignment
     for (const col of row.children) col.removeAttribute("style");
@@ -42,7 +42,7 @@ if (currentView.startsWith("/APP/EXAMRESULTS/")) {
         const parser = new DOMParser();
         const doc = parser.parseFromString(await s.text(), "text/html");
 
-        return { doc, elm: lastCol };
+        return { doc, elm: lastCol, url };
       }),
     );
   }
@@ -52,7 +52,7 @@ if (currentView.startsWith("/APP/EXAMRESULTS/")) {
 
     for (let i = 0; i < gradeOverviews.length; i++) {
       // Parse the grade distributions
-      const { doc, elm } = gradeOverviews[i];
+      const { doc, elm, url } = gradeOverviews[i];
       const tableBody = doc.querySelector("tbody")!;
       const values = [...tableBody.children].map((tr) => {
         const gradeText = tr.children.item(0)!.textContent!.replace(",", ".");
@@ -71,7 +71,7 @@ if (currentView.startsWith("/APP/EXAMRESULTS/")) {
       // .slice(0, -2); // Remove the 5.0 from all lists
 
       // Present the bar chart
-      const graphSVG = Graphing.createSVGGradeDistributionGraph(values);
+      const graphSVG = Graphing.createSVGGradeDistributionGraph(values, url);
       elm.innerHTML = graphSVG;
     }
 
@@ -79,6 +79,16 @@ if (currentView.startsWith("/APP/EXAMRESULTS/")) {
     const tableHeadRow = document.querySelector("thead>tr")!;
     tableHeadRow.children.item(3)!.removeAttribute("style");
   })();
+  /*
+
+
+
+
+
+
+
+
+*/
 } else if (currentView.startsWith("/APP/COURSERESULTS/")) {
   // Prüfungen > Ergebnisse
 
@@ -87,7 +97,7 @@ if (currentView.startsWith("/APP/EXAMRESULTS/")) {
   headRow.removeChild(headRow.children.item(3)!);
 
   const body = document.querySelector("tbody")!;
-  const promises: Promise<{ doc: Document; elm: Element }>[] = [];
+  const promises: Promise<{ doc: Document; elm: Element; url: string }>[] = [];
   for (const row of body.children) {
     // Remove useless inline styles which set the vertical alignment
     for (const col of row.children) col.removeAttribute("style");
@@ -115,7 +125,7 @@ if (currentView.startsWith("/APP/EXAMRESULTS/")) {
         const parser = new DOMParser();
         const doc = parser.parseFromString(await s.text(), "text/html");
 
-        return { doc, elm: lastCol };
+        return { doc, elm: lastCol, url };
       }),
     );
   }
@@ -125,7 +135,7 @@ if (currentView.startsWith("/APP/EXAMRESULTS/")) {
 
     for (let i = 0; i < gradeOverviews.length; i++) {
       // Parse the grade distributions
-      const { doc, elm } = gradeOverviews[i];
+      const { doc, elm, url } = gradeOverviews[i];
       const tableBody = doc.querySelector("tbody")!;
       const values = [...tableBody.children].map((tr) => {
         const gradeText = tr.children.item(0)!.textContent!.replace(",", ".");
@@ -144,7 +154,7 @@ if (currentView.startsWith("/APP/EXAMRESULTS/")) {
       // .slice(0, -2); // Remove the 5.0 from all lists
 
       // Present the bar chart
-      const graphSVG = Graphing.createSVGGradeDistributionGraph(values);
+      const graphSVG = Graphing.createSVGGradeDistributionGraph(values, url);
       elm.innerHTML = graphSVG;
     }
 
@@ -253,6 +263,7 @@ namespace Graphing {
 
   export function createSVGGradeDistributionGraph(
     values: GradeStat[],
+    url: string,
     width = 200,
     height = 100,
   ): string {
@@ -300,7 +311,9 @@ namespace Graphing {
       <svg
         viewBox="0 0 ${width} ${height}"
         xmlns="http://www.w3.org/2000/svg">
-        ${barsSvg}
+        <a href="${url}" target="popup">
+          ${barsSvg}
+        </a>
       </svg>
     `;
   }

--- a/src/contentScripts/other/selma/layout.ts
+++ b/src/contentScripts/other/selma/layout.ts
@@ -19,6 +19,7 @@ if (currentView.startsWith("/APP/EXAMRESULTS/")) {
   // Remove the "gut/befriedigend" section
   const headRow = document.querySelector("thead>tr")!;
   headRow.removeChild(headRow.children.item(3)!);
+  headRow.children.item(3)!.textContent = "Notenverteilung";
 
   const body = document.querySelector("tbody")!;
   const promises: Promise<{ doc: Document; elm: Element; url: string }>[] = [];
@@ -91,6 +92,14 @@ if (currentView.startsWith("/APP/EXAMRESULTS/")) {
   // Remove the "bestanden" section
   const headRow = document.querySelector("thead>tr")!;
   headRow.removeChild(headRow.children.item(3)!);
+
+  // Add "Notenverteilung" header
+  {
+    headRow.children.item(3)!.removeAttribute("colspan");
+    const newHeader = document.createElement("th");
+    newHeader.textContent = "Notenverteilung";
+    headRow.appendChild(newHeader);
+  }
 
   const body = document.querySelector("tbody")!;
   const promises: Promise<{ doc: Document; elm: Element; url: string }>[] = [];

--- a/src/contentScripts/other/selma/layout.ts
+++ b/src/contentScripts/other/selma/layout.ts
@@ -47,12 +47,8 @@ if (currentView.startsWith("/APP/EXAMRESULTS/")) {
     );
   }
 
-  (async () => {
-    const gradeOverviews = await Promise.all(promises);
-
-    for (let i = 0; i < gradeOverviews.length; i++) {
-      // Parse the grade distributions
-      const { doc, elm, url } = gradeOverviews[i];
+  promises.forEach((p) =>
+    p.then(({ doc, elm, url }) => {
       const tableBody = doc.querySelector("tbody")!;
       const values = [...tableBody.children].map((tr) => {
         const gradeText = tr.children.item(0)!.textContent!.replace(",", ".");
@@ -73,12 +69,12 @@ if (currentView.startsWith("/APP/EXAMRESULTS/")) {
       // Present the bar chart
       const graphSVG = Graphing.createSVGGradeDistributionGraph(values, url);
       elm.innerHTML = graphSVG;
-    }
+    }),
+  );
 
-    // Remove the inline style that sets a width on the top right table cell
-    const tableHeadRow = document.querySelector("thead>tr")!;
-    tableHeadRow.children.item(3)!.removeAttribute("style");
-  })();
+  // Remove the inline style that sets a width on the top right table cell
+  const tableHeadRow = document.querySelector("thead>tr")!;
+  tableHeadRow.children.item(3)!.removeAttribute("style");
   /*
 
 
@@ -130,12 +126,9 @@ if (currentView.startsWith("/APP/EXAMRESULTS/")) {
     );
   }
 
-  (async () => {
-    const gradeOverviews = await Promise.all(promises);
-
-    for (let i = 0; i < gradeOverviews.length; i++) {
+  promises.forEach((p) =>
+    p.then(({ doc, elm, url }) => {
       // Parse the grade distributions
-      const { doc, elm, url } = gradeOverviews[i];
       const tableBody = doc.querySelector("tbody")!;
       const values = [...tableBody.children].map((tr) => {
         const gradeText = tr.children.item(0)!.textContent!.replace(",", ".");
@@ -156,12 +149,12 @@ if (currentView.startsWith("/APP/EXAMRESULTS/")) {
       // Present the bar chart
       const graphSVG = Graphing.createSVGGradeDistributionGraph(values, url);
       elm.innerHTML = graphSVG;
-    }
+    }),
+  );
 
-    // Remove the inline style that sets a width on the top right table cell
-    const tableHeadRow = document.querySelector("thead>tr")!;
-    tableHeadRow.children.item(3)!.removeAttribute("style");
-  })();
+  // Remove the inline style that sets a width on the top right table cell
+  const tableHeadRow = document.querySelector("thead>tr")!;
+  tableHeadRow.children.item(3)!.removeAttribute("style");
 }
 
 /*

--- a/src/contentScripts/other/selma/layout.ts
+++ b/src/contentScripts/other/selma/layout.ts
@@ -244,6 +244,7 @@ function createCreditsBanner () {
   disableButton.onclick = async (event) => {
     event.preventDefault()
     await chrome.storage.local.set({ improveSelma: false })
+    window.location.reload()
   }
   credits.appendChild(disableButton)
 

--- a/src/contentScripts/other/selma/layout.ts
+++ b/src/contentScripts/other/selma/layout.ts
@@ -208,13 +208,17 @@ if (currentView.startsWith("/APP/EXAMRESULTS/")) {
       }
     }
 
+    {
+      // Remove useless timespans
+      const dateElm = botRow.children.item(1)!;
+      dateElm.textContent = dateElm.textContent!.replaceAll("00:00-00:00", "");
+    }
+
     // Table head "Prüfungsleistung"
     document.querySelector("thead > tr > th#Name")!.textContent = "";
     // Table head "Termin"
     document.querySelector("thead > tr > th#Date")!.textContent =
       "Prüfungsleistung/Termin";
-
-    console.log(thElm);
   }
 }
 /*

--- a/src/contentScripts/other/selma/layout.ts
+++ b/src/contentScripts/other/selma/layout.ts
@@ -1,0 +1,17 @@
+const currentView = document.location.pathname;
+
+if (currentView.startsWith("/APP/EXAMRESULTS/")) {
+  // Prüfungen > Ergebnisse
+
+  // Remove the "gut/befriedigend" section
+  const headRow = document.querySelector("thead>tr")!;
+  headRow.removeChild(headRow.children.item(3)!);
+
+  const body = document.querySelector("tbody")!;
+  for (const row of body.children) {
+    row.removeChild(row.children.item(3)!);
+
+    const firstCol = row.children.item(0)!;
+    firstCol.querySelector("div")!.style.color = "rgb(102, 102, 102)";
+  }
+}

--- a/src/contentScripts/other/selma/layout.ts
+++ b/src/contentScripts/other/selma/layout.ts
@@ -1,4 +1,63 @@
 const currentView = document.location.pathname;
+// Regex for extracting Programm name and arguments from a popup Script
+// This is used to get the URL which would be opened in a popup
+const popupScriptsRegex =
+  /Message = dl_popUp\("\/scripts\/mgrqispi\.dll\?APPNAME=CampusNet&PRGNAME=(\w+)&ARGUMENTS=([^"]+)"/;
+
+function scriptToURL(script: string): string {
+  const matches = script.match(popupScriptsRegex)!;
+
+  const porgamName = matches.at(1)!;
+  const prgArguments = matches.at(2)!;
+
+  return `https://selma.tu-dresden.de/APP/${porgamName}/${prgArguments}`;
+}
+
+type GradeStat = {
+  grade: number;
+  count: number;
+};
+
+function maxGradeCount(values: GradeStat[]): number {
+  let max = 0;
+  for (const { grade, count } of values) {
+    if (count > max) max = count;
+  }
+  return max;
+}
+
+function totalGradeCount(values: GradeStat[]): number {
+  return values.map(({ grade, count }) => count).reduce((p, c) => p + c);
+}
+
+function calculateAverage(values: GradeStat[]): number {
+  return (
+    values.map(({ grade, count }) => grade * count).reduce((p, c) => p + c) /
+    totalGradeCount(values)
+  );
+}
+
+// Reduce the grade increments
+function pickGradeSubset(values: GradeStat[]): GradeStat[] {
+  const increments = [1, 1.3, 1.7, 2, 2.3, 2.7, 3, 3.3, 3.7, 4];
+
+  const newValues = increments.map((inc) => ({
+    grade: inc,
+    count: 0,
+  }));
+
+  let currentIncIndex = 0;
+  for (const { grade, count } of values) {
+    // Skip to next increment if we reached it's lower end
+    if (currentIncIndex !== increments.length - 1) {
+      const nextIncrement = increments[currentIncIndex + 1];
+      if (grade >= nextIncrement) currentIncIndex++;
+    }
+    newValues[currentIncIndex].count += count;
+  }
+
+  return newValues;
+}
 
 if (currentView.startsWith("/APP/EXAMRESULTS/")) {
   // Prüfungen > Ergebnisse
@@ -8,10 +67,88 @@ if (currentView.startsWith("/APP/EXAMRESULTS/")) {
   headRow.removeChild(headRow.children.item(3)!);
 
   const body = document.querySelector("tbody")!;
+  const promises: Promise<{ doc: Document; elm: Element }>[] = [];
   for (const row of body.children) {
     row.removeChild(row.children.item(3)!);
 
-    const firstCol = row.children.item(0)!;
-    firstCol.querySelector("div")!.style.color = "rgb(102, 102, 102)";
+    const lastCol = row.children.item(3)!;
+    const scriptContent = lastCol.children.item(1)!.innerHTML;
+
+    const url = scriptToURL(scriptContent);
+
+    promises.push(
+      fetch(url).then(async (s) => {
+        const parser = new DOMParser();
+        const doc = parser.parseFromString(await s.text(), "text/html");
+
+        return { doc, elm: lastCol };
+      }),
+    );
   }
+
+  (async () => {
+    const gradeOverviews = await Promise.all(promises);
+
+    for (let i = 0; i < gradeOverviews.length; i++) {
+      const { doc, elm } = gradeOverviews[i];
+      const tableBody = doc.querySelector("tbody")!;
+      const values = [...tableBody.children]
+        .map((tr) => {
+          const gradeText = tr.children.item(0)!.textContent!.replace(",", ".");
+          const grade = parseFloat(gradeText);
+
+          const countText = tr.children.item(1)!.textContent!;
+          let count: number;
+          if (countText === "---") {
+            count = 0;
+          } else {
+            count = parseInt(countText);
+          }
+
+          return {
+            grade,
+            count,
+          };
+        })
+        .slice(0, -2); // Remove the 5.0 from all lists
+
+      // Avg
+      const avg = calculateAverage(values);
+      elm.innerHTML = `avg: ${avg.toFixed(2)}`;
+
+      // Drawing the Chart
+      const coarseValues = pickGradeSubset(values);
+
+      const width = 200;
+      const spacing = 0.1;
+      const barWidth = (width * (1 - spacing)) / coarseValues.length;
+      const height = 100;
+
+      let barsSvg = "";
+      const maxCount = maxGradeCount(coarseValues);
+      for (let x = 0; x < coarseValues.length; x++) {
+        const { grade, count } = coarseValues[x];
+        const barHeight = (count / maxCount) * height;
+
+        barsSvg += `
+        <rect
+          x="${x * barWidth * (1 + spacing)}" y="${height - barHeight}"
+          width="${barWidth}" height="${barHeight}"
+          rx="5" ry="5"
+        />
+        `;
+      }
+
+      elm.setAttribute("style", "vertical-align: middle;");
+      elm.innerHTML = `
+        <svg
+          viewBox="0 0 ${width} ${height}"
+          xmlns="http://www.w3.org/2000/svg">
+          ${barsSvg}
+        </svg>
+      `;
+
+      console.log(coarseValues);
+    }
+  })();
 }

--- a/src/freshContent/settings/Settings.vue
+++ b/src/freshContent/settings/Settings.vue
@@ -78,6 +78,7 @@ import AutoLogin from './settingPages/AutoLogin.vue'
 import Email from './settingPages/Email.vue'
 import OpalCourses from './settingPages/OpalCourses.vue'
 import ImproveOpal from './settingPages/ImproveOpal.vue'
+import SelmajExamTheme from './settingPages/SelmajExamTheme.vue'
 import Shortcuts from './settingPages/Shortcuts.vue'
 import SearchEngines from './settingPages/SearchEngines.vue'
 import Rockets from './settingPages/Rockets.vue'
@@ -115,6 +116,7 @@ export default defineComponent({
     Email,
     OpalCourses,
     ImproveOpal,
+    SelmajExamTheme,
     Shortcuts,
     SearchEngines,
     Rockets,

--- a/src/freshContent/settings/Settings.vue
+++ b/src/freshContent/settings/Settings.vue
@@ -78,7 +78,7 @@ import AutoLogin from './settingPages/AutoLogin.vue'
 import Email from './settingPages/Email.vue'
 import OpalCourses from './settingPages/OpalCourses.vue'
 import ImproveOpal from './settingPages/ImproveOpal.vue'
-import SelmajExamTheme from './settingPages/SelmajExamTheme.vue'
+import ImproveSelma from './settingPages/ImproveSelma.vue'
 import Shortcuts from './settingPages/Shortcuts.vue'
 import SearchEngines from './settingPages/SearchEngines.vue'
 import Rockets from './settingPages/Rockets.vue'
@@ -116,7 +116,7 @@ export default defineComponent({
     Email,
     OpalCourses,
     ImproveOpal,
-    SelmajExamTheme,
+    ImproveSelma,
     Shortcuts,
     SearchEngines,
     Rockets,

--- a/src/freshContent/settings/components/SettingTile.vue
+++ b/src/freshContent/settings/components/SettingTile.vue
@@ -19,7 +19,7 @@
 <script lang="ts">
 import { defineComponent, PropType } from 'vue'
 // Temporary fix: We need to import the Componentes for the icons manually as no global usage is possible
-import { PhLockKey, PhNotification, PhListDashes, PhSparkle, PhGauge, PhGoogleLogo, PhRocket, PhEnvelopeOpen } from '@dnlsndr/vue-phosphor-icons'
+import { PhLockKey, PhNotification, PhListDashes, PhSparkle, PhChartBar, PhGauge, PhGoogleLogo, PhRocket, PhEnvelopeOpen } from '@dnlsndr/vue-phosphor-icons'
 
 export default defineComponent({
   components: {
@@ -28,6 +28,7 @@ export default defineComponent({
     PhListDashes,
     PhSparkle,
     PhGauge,
+    PhChartBar,
     PhGoogleLogo,
     PhRocket,
     PhEnvelopeOpen

--- a/src/freshContent/settings/settingPages/ImproveSelma.vue
+++ b/src/freshContent/settings/settingPages/ImproveSelma.vue
@@ -1,13 +1,13 @@
 <template>
   <p class="max-line p-margin">
-    Dieses feature fügt Graphen für die Notenverteilungen und Versuchstracker in
-    selma hinzu. Zusätzlich wird das layout und design angepasst
-    um allgemein benutzerfreundlicher zu sein.
+    Dieses Feature fügt Graphen für die Notenverteilungen und Versuchstracker in
+    Selma hinzu. Zusätzlich wird das Layout und Design angepasst,
+    um benutzerfreundlicher zu sein.
   </p>
 
   <Setting
     v-model="improveSelma"
-    txt="Das verbesserte layout und die Notenverteilung bei Selma benutzen"
+    txt="Das verbesserte Layout und die Notenverteilung bei Selma benutzen"
     class="setting"
   />
 </template>

--- a/src/freshContent/settings/settingPages/ImproveSelma.vue
+++ b/src/freshContent/settings/settingPages/ImproveSelma.vue
@@ -2,12 +2,12 @@
   <p class="max-line p-margin">
     Dieses feature fügt Graphen für die Notenverteilungen und Versuchstracker in
     selma hinzu. Zusätzlich wird das layout und design angepasst
-    umbenutzerfreundlicher zu sein.
+    um allgemein benutzerfreundlicher zu sein.
   </p>
 
   <Setting
     v-model="selmajExamTheme"
-    txt="Das jExam theme bei Selma benutzen"
+    txt="Das verbesserte layout und die Notenverteilung bei Selma benutzen"
     class="setting"
   />
 </template>
@@ -23,14 +23,14 @@ export default defineComponent({
     Setting
   },
   setup () {
-    const selmajExamTheme = ref(false)
+    const selmajExamTheme = ref(true)
 
     onBeforeMount(async () => {
       const { selmajExamTheme: storedValue } = await chrome.storage.local.get([
         'selmajExamTheme'
       ])
 
-      selmajExamTheme.value = storedValue ?? false
+      selmajExamTheme.value = storedValue ?? true
       watch(selmajExamTheme, valueUpdate)
     })
 

--- a/src/freshContent/settings/settingPages/ImproveSelma.vue
+++ b/src/freshContent/settings/settingPages/ImproveSelma.vue
@@ -6,7 +6,7 @@
   </p>
 
   <Setting
-    v-model="selmajExamTheme"
+    v-model="improveSelma"
     txt="Das verbesserte layout und die Notenverteilung bei Selma benutzen"
     class="setting"
   />
@@ -23,26 +23,26 @@ export default defineComponent({
     Setting
   },
   setup () {
-    const selmajExamTheme = ref(true)
+    const improveSelma = ref(true)
 
     onBeforeMount(async () => {
-      const { selmajExamTheme: storedValue } = await chrome.storage.local.get([
-        'selmajExamTheme'
+      const { improveSelma: storedValue } = await chrome.storage.local.get([
+        'improveSelma'
       ])
 
-      selmajExamTheme.value = storedValue ?? true
-      watch(selmajExamTheme, valueUpdate)
+      improveSelma.value = storedValue ?? true
+      watch(improveSelma, valueUpdate)
     })
 
     const valueUpdate = async () => {
       // When we got here, we have the permission
       await chrome.storage.local.set({
-        selmajExamTheme: selmajExamTheme.value
+        improveSelma: improveSelma.value
       })
     }
 
     return {
-      selmajExamTheme
+      improveSelma
     }
   }
 })

--- a/src/freshContent/settings/settingPages/SelmajExamTheme.vue
+++ b/src/freshContent/settings/settingPages/SelmajExamTheme.vue
@@ -13,39 +13,39 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, onBeforeMount, ref, watch } from "vue";
+import { defineComponent, onBeforeMount, ref, watch } from 'vue'
 
 // components
-import Setting from "../components/Setting.vue";
+import Setting from '../components/Setting.vue'
 
 export default defineComponent({
   components: {
-    Setting,
+    Setting
   },
-  setup() {
-    const selmajExamTheme = ref(false);
+  setup () {
+    const selmajExamTheme = ref(false)
 
     onBeforeMount(async () => {
       const { selmajExamTheme: storedValue } = await chrome.storage.local.get([
-        "selmajExamTheme",
-      ]);
+        'selmajExamTheme'
+      ])
 
-      selmajExamTheme.value = storedValue ?? false;
-      watch(selmajExamTheme, valueUpdate);
-    });
+      selmajExamTheme.value = storedValue ?? false
+      watch(selmajExamTheme, valueUpdate)
+    })
 
     const valueUpdate = async () => {
       // When we got here, we have the permission
       await chrome.storage.local.set({
-        selmajExamTheme: selmajExamTheme.value,
-      });
-    };
+        selmajExamTheme: selmajExamTheme.value
+      })
+    }
 
     return {
-      selmajExamTheme,
-    };
-  },
-});
+      selmajExamTheme
+    }
+  }
+})
 </script>
 
 <style lang="sass" scoped>

--- a/src/freshContent/settings/settingPages/SelmajExamTheme.vue
+++ b/src/freshContent/settings/settingPages/SelmajExamTheme.vue
@@ -1,0 +1,54 @@
+<template>
+  <p class="max-line p-margin">
+    Dieses feature fügt Graphen für die Notenverteilungen und Versuchstracker in
+    selma hinzu. Zusätzlich wird das layout und design angepasst
+    umbenutzerfreundlicher zu sein.
+  </p>
+
+  <Setting
+    v-model="selmajExamTheme"
+    txt="Das jExam theme bei Selma benutzen"
+    class="setting"
+  />
+</template>
+
+<script lang="ts">
+import { defineComponent, onBeforeMount, ref, watch } from "vue";
+
+// components
+import Setting from "../components/Setting.vue";
+
+export default defineComponent({
+  components: {
+    Setting,
+  },
+  setup() {
+    const selmajExamTheme = ref(false);
+
+    onBeforeMount(async () => {
+      const { selmajExamTheme: storedValue } = await chrome.storage.local.get([
+        "selmajExamTheme",
+      ]);
+
+      selmajExamTheme.value = storedValue ?? false;
+      watch(selmajExamTheme, valueUpdate);
+    });
+
+    const valueUpdate = async () => {
+      // When we got here, we have the permission
+      await chrome.storage.local.set({
+        selmajExamTheme: selmajExamTheme.value,
+      });
+    };
+
+    return {
+      selmajExamTheme,
+    };
+  },
+});
+</script>
+
+<style lang="sass" scoped>
+.setting
+    margin-bottom: .8rem
+</style>

--- a/src/freshContent/settings/settings.json
+++ b/src/freshContent/settings/settings.json
@@ -20,9 +20,9 @@
         "settingsPage": "ImproveOpal"
     },
     {
-        "title": "Selma jExam Theme",
-        "icon": "PhSparkle",
-        "settingsPage": "SelmajExamTheme"
+        "title": "Selma verbessern",
+        "icon": "PhChartBar",
+        "settingsPage": "ImproveSelma"
     },
     {
         "title": "Shortcuts",

--- a/src/freshContent/settings/settings.json
+++ b/src/freshContent/settings/settings.json
@@ -20,6 +20,11 @@
         "settingsPage": "ImproveOpal"
     },
     {
+        "title": "Selma jExam Theme",
+        "icon": "PhSparkle",
+        "settingsPage": "SelmajExamTheme"
+    },
+    {
         "title": "Shortcuts",
         "icon": "PhGauge",
         "settingsPage": "Shortcuts"

--- a/src/manifest.chrome.json
+++ b/src/manifest.chrome.json
@@ -84,6 +84,11 @@
       "matches": ["https://selma.tu-dresden.de/*"]
     },
     {
+      "js": ["contentScripts/other/selma/layout.js"],
+      "run_at": "document_start",
+      "matches": ["https://selma.tu-dresden.de/*"]
+    },
+    {
       "js": ["contentScripts/login/qis.js"],
       "run_at": "document_idle",
       "matches": ["https://qis.dez.tu-dresden.de/qisserver/servlet*"]
@@ -263,6 +268,10 @@
       "snowpack/pkg/*"
     ],
     "matches": ["https://qis.dez.tu-dresden.de/*"]
+  },
+  {
+    "resources": ["styles/contentScripts/selma/*"],
+    "matches": ["https://selma.tu-dresden.de/*"]
   }],
   "manifest_version": 3,
   "commands": {

--- a/src/manifest.firefox.json
+++ b/src/manifest.firefox.json
@@ -74,30 +74,14 @@
       ]
     },
     {
-      "js": [
-        "contentScripts/login/selma.js",
-        "contentScripts/other/selma/layout.js"
-      ],
+      "js": ["contentScripts/login/selma.js"],
       "run_at": "document_idle",
       "matches": ["https://selma.tu-dresden.de/*"]
     },
     {
-      "css": ["styles/contentScripts/selma/base.css"],
-      "run_at": "document_idle",
+      "js": ["contentScripts/other/selma/layout.js"],
+      "run_at": "document_start",
       "matches": ["https://selma.tu-dresden.de/*"]
-    },
-    {
-      "css": ["styles/contentScripts/selma/my_exams.css"],
-      "run_at": "document_idle",
-      "matches": ["https://selma.tu-dresden.de/APP/MYEXAMS/*"]
-    },
-    {
-      "css": ["styles/contentScripts/selma/exam_results.css"],
-      "run_at": "document_idle",
-      "matches": [
-        "https://selma.tu-dresden.de/APP/EXAMRESULTS/*",
-        "https://selma.tu-dresden.de/APP/COURSERESULTS/*"
-      ]
     },
     {
       "js": ["contentScripts/login/qis.js"],
@@ -274,6 +258,10 @@
     {
       "resources": ["contentScripts/other/hisqis/*", "snowpack/pkg/*"],
       "matches": ["https://qis.dez.tu-dresden.de/*"]
+    },
+    {
+      "resources": ["styles/contentScripts/selma/*"],
+      "matches": ["https://selma.tu-dresden.de/*"]
     }
   ],
   "manifest_version": 3,

--- a/src/manifest.firefox.json
+++ b/src/manifest.firefox.json
@@ -83,17 +83,17 @@
     },
     {
       "css": ["styles/contentScripts/selma/base.css"],
-      "run_at": "document_start",
+      "run_at": "document_idle",
       "matches": ["https://selma.tu-dresden.de/*"]
     },
     {
       "css": ["styles/contentScripts/selma/my_exams.css"],
-      "run_at": "document_start",
+      "run_at": "document_idle",
       "matches": ["https://selma.tu-dresden.de/APP/MYEXAMS/*"]
     },
     {
       "css": ["styles/contentScripts/selma/exam_results.css"],
-      "run_at": "document_start",
+      "run_at": "document_idle",
       "matches": [
         "https://selma.tu-dresden.de/APP/EXAMRESULTS/*",
         "https://selma.tu-dresden.de/APP/COURSERESULTS/*"

--- a/src/manifest.firefox.json
+++ b/src/manifest.firefox.json
@@ -74,7 +74,10 @@
       ]
     },
     {
-      "js": ["contentScripts/login/selma.js"],
+      "js": [
+        "contentScripts/login/selma.js",
+        "contentScripts/other/selma/layout.js"
+      ],
       "run_at": "document_idle",
       "matches": ["https://selma.tu-dresden.de/*"]
     },
@@ -82,6 +85,16 @@
       "css": ["styles/contentScripts/selma/base.css"],
       "run_at": "document_start",
       "matches": ["https://selma.tu-dresden.de/*"]
+    },
+    {
+      "css": ["styles/contentScripts/selma/my_exams.css"],
+      "run_at": "document_start",
+      "matches": ["https://selma.tu-dresden.de/APP/MYEXAMS/*"]
+    },
+    {
+      "css": ["styles/contentScripts/selma/exam_results.css"],
+      "run_at": "document_start",
+      "matches": ["https://selma.tu-dresden.de/APP/EXAMRESULTS/*"]
     },
     {
       "js": ["contentScripts/login/qis.js"],

--- a/src/manifest.firefox.json
+++ b/src/manifest.firefox.json
@@ -2,10 +2,7 @@
   "name": "TUfast TU Dresden",
   "version": "8.1.0.1",
   "description": "Das Produktivitäts-Tool für TU Dresden Studierende 🚀",
-  "permissions": [
-    "storage",
-    "alarms"
-  ],
+  "permissions": ["storage", "alarms"],
   "optional_permissions": [
     "tabs",
     "notifications",
@@ -13,9 +10,7 @@
     "webRequest",
     "webRequestBlocking"
   ],
-  "host_permissions": [
-    "*://*/"
-  ],
+  "host_permissions": ["*://*/"],
   "background": {
     "scripts": ["background.js"],
     "type": "module"
@@ -81,6 +76,11 @@
     {
       "js": ["contentScripts/login/selma.js"],
       "run_at": "document_idle",
+      "matches": ["https://selma.tu-dresden.de/*"]
+    },
+    {
+      "css": ["styles/contentScripts/selma/base.css"],
+      "run_at": "document_start",
       "matches": ["https://selma.tu-dresden.de/*"]
     },
     {
@@ -223,47 +223,43 @@
     "page": "freshContent/settings/index.html",
     "open_in_tab": true
   },
-  "web_accessible_resources": [{
-    "resources": [
-      "assets/*",
-      "contentScripts/other/notification.js"
-    ],
-    "matches": ["<all_urls>"]
-  },
-  {
-    "resources": ["contentScripts/login/common.js"],
-    "matches": [
-      "https://*.tu-dresden.de/*",
-      "https://bildungsportal.sachsen.de/*",
-      "https://videocampus.sachsen.de/*",
-      "https://git.imld.de/*",
-      "https://gitlab.hrz.tu-chemnitz.de/*",
-      "https://*.slub-dresden.de/*"
-    ]
-  },
-  {
-    "resources": [
-      "contentScripts/forward/searchEngines/common.js",
-      "contentScripts/forward/searchEngines/sites.json*"
-    ],
-    "matches": [
-      "https://www.startpage.com/*",
-      "https://www.qwant.com/*",
-      "https://www.google.de/*",
-      "https://www.google.com/*",
-      "https://duckduckgo.com/*",
-      "https://www.ecosia.org/*",
-      "https://www.bing.com/*",
-      "https://search.brave.com/*"
-    ]
-  },
-  {
-    "resources": [
-      "contentScripts/other/hisqis/*",
-      "snowpack/pkg/*"
-    ],
-    "matches": ["https://qis.dez.tu-dresden.de/*"]
-  }],
+  "web_accessible_resources": [
+    {
+      "resources": ["assets/*", "contentScripts/other/notification.js"],
+      "matches": ["<all_urls>"]
+    },
+    {
+      "resources": ["contentScripts/login/common.js"],
+      "matches": [
+        "https://*.tu-dresden.de/*",
+        "https://bildungsportal.sachsen.de/*",
+        "https://videocampus.sachsen.de/*",
+        "https://git.imld.de/*",
+        "https://gitlab.hrz.tu-chemnitz.de/*",
+        "https://*.slub-dresden.de/*"
+      ]
+    },
+    {
+      "resources": [
+        "contentScripts/forward/searchEngines/common.js",
+        "contentScripts/forward/searchEngines/sites.json*"
+      ],
+      "matches": [
+        "https://www.startpage.com/*",
+        "https://www.qwant.com/*",
+        "https://www.google.de/*",
+        "https://www.google.com/*",
+        "https://duckduckgo.com/*",
+        "https://www.ecosia.org/*",
+        "https://www.bing.com/*",
+        "https://search.brave.com/*"
+      ]
+    },
+    {
+      "resources": ["contentScripts/other/hisqis/*", "snowpack/pkg/*"],
+      "matches": ["https://qis.dez.tu-dresden.de/*"]
+    }
+  ],
   "manifest_version": 3,
   "browser_specific_settings": {
     "gecko": {

--- a/src/manifest.firefox.json
+++ b/src/manifest.firefox.json
@@ -94,7 +94,10 @@
     {
       "css": ["styles/contentScripts/selma/exam_results.css"],
       "run_at": "document_start",
-      "matches": ["https://selma.tu-dresden.de/APP/EXAMRESULTS/*"]
+      "matches": [
+        "https://selma.tu-dresden.de/APP/EXAMRESULTS/*",
+        "https://selma.tu-dresden.de/APP/COURSERESULTS/*"
+      ]
     },
     {
       "js": ["contentScripts/login/qis.js"],

--- a/src/styles/contentScripts/selma/base.scss
+++ b/src/styles/contentScripts/selma/base.scss
@@ -1,5 +1,5 @@
 .pageContent {
   min-width: unset;
   max-width: unset;
-  padding: 3rem 10vh 5rem 5rem;
+  padding: 3rem 5vw 5rem 5rem;
 }

--- a/src/styles/contentScripts/selma/base.scss
+++ b/src/styles/contentScripts/selma/base.scss
@@ -1,0 +1,33 @@
+.pageContent {
+  min-width: unset;
+  max-width: unset;
+  padding: 3rem 10vh 5rem 5rem;
+}
+
+tbody > tr > th {
+  /*
+    text-align: left;
+  vertical-align: top;
+  padding-top: 1.3rem;
+  padding-bottom: 1.3rem;
+  background: #e7eaf0;
+  color: #666;
+  font-weight: 400;
+
+  */
+  padding-top: 2rem;
+  padding-bottom: 0.5rem;
+  background: unset;
+}
+
+tbody > tr > td {
+  background: unset;
+  border-bottom: 1px solid #ccc;
+  padding-top: 0.5rem;
+  padding-bottom: 2rem;
+}
+
+tbody :nth-child(4n of tr),
+tbody :nth-child(4n - 1 of tr) {
+  background: #e7eaf0;
+}

--- a/src/styles/contentScripts/selma/base.scss
+++ b/src/styles/contentScripts/selma/base.scss
@@ -3,31 +3,3 @@
   max-width: unset;
   padding: 3rem 10vh 5rem 5rem;
 }
-
-tbody > tr > th {
-  /*
-    text-align: left;
-  vertical-align: top;
-  padding-top: 1.3rem;
-  padding-bottom: 1.3rem;
-  background: #e7eaf0;
-  color: #666;
-  font-weight: 400;
-
-  */
-  padding-top: 2rem;
-  padding-bottom: 0.5rem;
-  background: unset;
-}
-
-tbody > tr > td {
-  background: unset;
-  border-bottom: 1px solid #ccc;
-  padding-top: 0.5rem;
-  padding-bottom: 2rem;
-}
-
-tbody :nth-child(4n of tr),
-tbody :nth-child(4n - 1 of tr) {
-  background: #e7eaf0;
-}

--- a/src/styles/contentScripts/selma/exam_results.scss
+++ b/src/styles/contentScripts/selma/exam_results.scss
@@ -1,7 +1,9 @@
+// Better spacing of the table content
 table {
   line-height: 1.5;
 }
 
+// Alternating background and separator lines
 tbody > tr > th {
   padding-top: 2rem;
   padding-bottom: 0.5rem;
@@ -22,25 +24,39 @@ tbody > tr.tbdata ::first-line {
   color: black;
 }
 
+// Make the bottom text gray in the "Prüfungsleistung section"
 tbody > tr.tbdata > td ::first-line {
   color: #666;
 }
 
+// The diagram
 tbody > tr.tbdata > td > svg {
   height: 3lh;
   display: block;
   margin-left: auto;
   margin-right: auto;
-  fill: #315584;
+
+  .passed {
+    fill: #315584;
+  }
+
+  .failed {
+    fill: #dd272757;
+  }
 }
 
 tbody > tr.tbdata > td :has(svg) {
   vertical-align: middle;
 }
 
-/*
-thead :nth-child(4) {
-  width: 100%;
-  padding: 0;
+// Date styling
+tbody > tr.tbdata :nth-child(2 of td) {
+  vertical-align: middle;
 }
-*/
+
+// Grade styling
+tbody > tr.tbdata :nth-child(3 of td) {
+  vertical-align: middle;
+  text-align: center;
+  font-size: 1.7rem;
+}

--- a/src/styles/contentScripts/selma/exam_results.scss
+++ b/src/styles/contentScripts/selma/exam_results.scss
@@ -1,3 +1,7 @@
+table {
+  line-height: 1.5;
+}
+
 tbody > tr > th {
   padding-top: 2rem;
   padding-bottom: 0.5rem;
@@ -8,7 +12,6 @@ tbody > tr > td {
   background: unset;
   border-bottom: 1px solid #ccc;
   padding-top: 0.5rem;
-  padding-bottom: 2rem;
 }
 
 tbody :nth-child(2n of tr) {
@@ -21,4 +24,18 @@ tbody > tr.tbdata ::first-line {
 
 tbody > tr.tbdata > td ::first-line {
   color: #666;
+}
+
+tbody > tr.tbdata > td > svg {
+  // width: 10rem;
+  display: block;
+  // margin: auto;
+  height: 100%;
+  fill: #315584;
+  display: block;
+  max-height: 100%;
+}
+
+tbody > tr.tbdata > td :has(svg) {
+  vertical-align: middle;
 }

--- a/src/styles/contentScripts/selma/exam_results.scss
+++ b/src/styles/contentScripts/selma/exam_results.scss
@@ -1,0 +1,24 @@
+tbody > tr > th {
+  padding-top: 2rem;
+  padding-bottom: 0.5rem;
+  background: unset;
+}
+
+tbody > tr > td {
+  background: unset;
+  border-bottom: 1px solid #ccc;
+  padding-top: 0.5rem;
+  padding-bottom: 2rem;
+}
+
+tbody :nth-child(2n of tr) {
+  background: #e7eaf0;
+}
+
+tbody > tr.tbdata ::first-line {
+  color: black;
+}
+
+tbody > tr.tbdata > td ::first-line {
+  color: #666;
+}

--- a/src/styles/contentScripts/selma/exam_results.scss
+++ b/src/styles/contentScripts/selma/exam_results.scss
@@ -13,24 +13,28 @@ tbody > tr > th {
 tbody > tr > td {
   background: unset;
   border-bottom: 1px solid #ccc;
-  // padding-top: 0.5rem;
 }
 
 tbody :nth-child(2n of tr) {
   background: #e7eaf0;
 }
 
-tbody > tr.tbdata ::first-line {
-  color: black;
+tbody > tr ::first-line {
+  color: #002557;
 }
 
 // Make the bottom text gray in the "Prüfungsleistung section"
-tbody > tr.tbdata > td ::first-line {
+tbody > tr > td ::first-line {
   color: #666;
 }
 
+// Vertically center the text in all courseresult rows
+tbody > tr > td.tbdata {
+  vertical-align: middle;
+}
+
 // The diagram
-tbody > tr.tbdata > td > svg {
+tbody > tr > td > svg {
   height: 3lh;
   display: block;
   margin-left: auto;
@@ -45,17 +49,28 @@ tbody > tr.tbdata > td > svg {
   }
 }
 
-tbody > tr.tbdata > td :has(svg) {
+// Not sure if this helps
+tbody > tr > td :has(svg) {
   vertical-align: middle;
 }
 
+//Courseresults page
+tbody > tr > td.tbdata > svg {
+  height: 2lh;
+}
+
 // Date styling
+// tr.tbdata means it only applies to the Examresults page
 tbody > tr.tbdata :nth-child(2 of td) {
+  vertical-align: middle;
+}
+// td.tbdata means it only applies to the Courseresults page
+tbody > tr :nth-child(3 of td.tbdata) {
   vertical-align: middle;
 }
 
 // Grade styling
-tbody > tr.tbdata :nth-child(3 of td) {
+tbody > tr :nth-child(3 of td) {
   vertical-align: middle;
   text-align: center;
   font-size: 1.7rem;

--- a/src/styles/contentScripts/selma/exam_results.scss
+++ b/src/styles/contentScripts/selma/exam_results.scss
@@ -35,7 +35,6 @@ tbody > tr > td.tbdata {
 
 // The diagram
 tbody > tr > td > svg {
-  height: 3lh;
   display: block;
   margin-left: auto;
   margin-right: auto;
@@ -47,6 +46,23 @@ tbody > tr > td > svg {
   .failed {
     fill: #dd272757;
   }
+
+  .used {
+    fill: #315584;
+  }
+
+  .open {
+    fill: none;
+    stroke: #315584aa;
+  }
+
+  &.distribution-chart {
+    height: 3lh;
+  }
+
+  &.tries-counter {
+    height: 1lh;
+  }
 }
 
 // Not sure if this helps
@@ -55,7 +71,7 @@ tbody > tr > td :has(svg) {
 }
 
 //Courseresults page
-tbody > tr > td.tbdata > svg {
+tbody > tr > td.tbdata > svg.distribution-chart {
   height: 2lh;
 }
 

--- a/src/styles/contentScripts/selma/exam_results.scss
+++ b/src/styles/contentScripts/selma/exam_results.scss
@@ -75,3 +75,17 @@ tbody > tr :nth-child(3 of td) {
   text-align: center;
   font-size: 1.7rem;
 }
+
+// Align the Header texts
+thead > tr {
+  // "Note" / "Modulenote"
+  :nth-child(3) {
+    text-align: center;
+  }
+
+  // "Notenverteilung"
+  :nth-last-child(1),
+  :nth-last-child(2) {
+    text-align: center;
+  }
+}

--- a/src/styles/contentScripts/selma/exam_results.scss
+++ b/src/styles/contentScripts/selma/exam_results.scss
@@ -11,7 +11,7 @@ tbody > tr > th {
 tbody > tr > td {
   background: unset;
   border-bottom: 1px solid #ccc;
-  padding-top: 0.5rem;
+  // padding-top: 0.5rem;
 }
 
 tbody :nth-child(2n of tr) {
@@ -27,15 +27,20 @@ tbody > tr.tbdata > td ::first-line {
 }
 
 tbody > tr.tbdata > td > svg {
-  // width: 10rem;
+  height: 3lh;
   display: block;
-  // margin: auto;
-  height: 100%;
+  margin-left: auto;
+  margin-right: auto;
   fill: #315584;
-  display: block;
-  max-height: 100%;
 }
 
 tbody > tr.tbdata > td :has(svg) {
   vertical-align: middle;
 }
+
+/*
+thead :nth-child(4) {
+  width: 100%;
+  padding: 0;
+}
+*/

--- a/src/styles/contentScripts/selma/exam_results.scss
+++ b/src/styles/contentScripts/selma/exam_results.scss
@@ -44,7 +44,7 @@ tbody > tr > td > svg {
   }
 
   .failed {
-    fill: #dd272757;
+    fill: #dd2727aa;
   }
 
   .used {

--- a/src/styles/contentScripts/selma/my_exams.scss
+++ b/src/styles/contentScripts/selma/my_exams.scss
@@ -1,14 +1,21 @@
-tbody > tr > th {
-  padding-top: 2rem;
-  padding-bottom: 0.5rem;
-  background: unset;
-}
+//Alternating background
+tbody > tr {
+  > th {
+    padding-top: 2rem;
+    padding-bottom: 0.5rem;
+    background: unset;
+  }
 
-tbody > tr > td {
-  background: unset;
-  border-bottom: 1px solid #ccc;
-  padding-top: 0.5rem;
-  padding-bottom: 2rem;
+  > td {
+    background: unset;
+    border-bottom: 1px solid #ccc;
+    padding-top: 0.5rem;
+    padding-bottom: 2rem;
+
+    &.module-description {
+      padding-right: 2rem;
+    }
+  }
 }
 
 tbody :nth-child(4n of tr),

--- a/src/styles/contentScripts/selma/my_exams.scss
+++ b/src/styles/contentScripts/selma/my_exams.scss
@@ -1,0 +1,17 @@
+tbody > tr > th {
+  padding-top: 2rem;
+  padding-bottom: 0.5rem;
+  background: unset;
+}
+
+tbody > tr > td {
+  background: unset;
+  border-bottom: 1px solid #ccc;
+  padding-top: 0.5rem;
+  padding-bottom: 2rem;
+}
+
+tbody :nth-child(4n of tr),
+tbody :nth-child(4n - 1 of tr) {
+  background: #e7eaf0;
+}


### PR DESCRIPTION
### Description
I propose the following changes in my PR:
- Add an optional alternative layout for the Exam views of Selma
- Add grade distribution graphs
- Add an indicator that shows the amounts of tries already used on a module

The following before and after images visualize the change: 

![image](https://github.com/user-attachments/assets/e352ddae-ec01-46dc-8e75-b4f3f16b0645)
![image](https://github.com/user-attachments/assets/31e6d86e-66f6-455e-9c91-e1b75fe8b7fa)


![image](https://github.com/user-attachments/assets/ea5ab8f2-1b12-4359-b186-dca672fb63de)
![image](https://github.com/user-attachments/assets/3875ab53-60d6-4364-9aa9-74b3542db141)


![image](https://github.com/user-attachments/assets/ad658a2f-35d9-407b-adb7-dd6a8a568e53)
![image](https://github.com/user-attachments/assets/3cbfc8d4-7638-43ab-a202-ecd1c80f9ae8)



### Type of change
- [ ] Bug fix (non-breaking change which fixes a bug)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that might cause existing functionality to not work as expected)

### Further info
- [x] This change requires a documentation update
- [ ] I updated the documentation accordingly, if required
- [x] I commented my code where its useful

### Testing
We have 1500+ Users. Please test your changes thoroughly.
- [x] Tested my changes on Firefox
- [x] Tested my changes on Chromium-Based-Browsers
- [x] Successfully run `npm run test` locally

### Additional Information
The changes need to be turned on in the settings page, as of now the setting has the same Icon as the Opal settings. A different icon would probably be better but I am unfamiliar with the way the icons work so a bit of help would be appreciated :)

I also accidentally reformatted the `src/manifest.firefox.json` file, I hope this is not an issue