### PR TITLE
Update idp error detection

### DIFF
--- a/src/contentScripts/login/idp.ts
+++ b/src/contentScripts/login/idp.ts
@@ -49,7 +49,7 @@ const cookieSettings: CookieSettings = {
     }
 
     async findCredentialsError (): Promise<boolean | HTMLElement | Element | null> {
-      return document.querySelector('.content p font[color="red"]')
+      return document.querySelector(".output--error") ?? document.querySelector('.content p font[color="red"]')
     }
 
     async loginFieldsAvailable (): Promise<boolean | LoginFields> {


### PR DESCRIPTION
Should not only fix error detection on login, but prevent people from killing their 2FA account.

Can't test changes, as I don't have an ZIH account anymore.