### PR TITLE
Selma: Content script sometimes gets injected after DOMContentLoaded event on OperaGX

### DIFF
--- a/src/contentScripts/other/selma/layout.ts
+++ b/src/contentScripts/other/selma/layout.ts
@@ -201,6 +201,7 @@ async function createCreditsBanner() {
   const credits = document.createElement('p')
 
   credits.style.margin = 'auto'
+  credits.style.marginLeft = '10px'
   credits.style.marginRight = '0'
   credits.style.color = '#002557' // Selma theme color
   credits.id = 'TUfastCredits'
@@ -237,23 +238,24 @@ async function createCreditsBanner() {
   return credits
 }
 
+// Apply all custom changes once documentd loaded
 ;(async () => {
-  const { improveSelma } = await chrome.storage.local.get(['improveSelma'])
-
-  // Apply all custom changes
-  document.addEventListener('DOMContentLoaded', async () => {
-    // Add Credit banner with toggle button
-    const creditElm = await createCreditsBanner()
-    document.querySelector('.semesterChoice')!.appendChild(creditElm)
-
-    if (!improveSelma) return
-
-    eventListener()
-  })
+  if (document.readyState !== 'loading') {
+    await eventListener()
+  } else {
+    document.addEventListener('DOMContentLoaded', eventListener)
+  }
 })()
 
 async function eventListener() {
   document.removeEventListener('DOMContentLoaded', eventListener)
+
+  // Add Credit banner with toggle button
+  const creditElm = await createCreditsBanner()
+  document.querySelector('.semesterChoice')!.appendChild(creditElm)
+
+  const { improveSelma } = await chrome.storage.local.get(['improveSelma'])
+  if (!improveSelma) return
 
   // Inject css
   injectCSS('base')

--- a/src/contentScripts/other/selma/layout.ts
+++ b/src/contentScripts/other/selma/layout.ts
@@ -3,6 +3,11 @@ const currentView = document.location.pathname
 // This is used to get the URL which would be opened in a popup
 const popupScriptsRegex = /dl_popUp\("\/scripts\/mgrqispi\.dll\?APPNAME=CampusNet&PRGNAME=(\w+)&ARGUMENTS=([^"]+)"/
 
+// A promise that resolves to the setting value of `improveSelma`
+const improveSelmaEnabledPromise: Promise<boolean> = chrome.storage.local
+  .get(['improveSelma'])
+  .then((s) => s.improveSelma)
+
 function scriptToURL(script: string): string {
   const matches = script.match(popupScriptsRegex)!
 
@@ -195,7 +200,7 @@ Actual logic
 // Create a small banner that indicates the user that the site was modified
 // It also adds a small toggle to disable the table
 async function createCreditsBanner() {
-  const { improveSelma: settingEnabled } = await chrome.storage.local.get(['improveSelma'])
+  const settingEnabled = await improveSelmaEnabledPromise
 
   const imgUrl = chrome.runtime.getURL('/assets/images/tufast48.png')
   const credits = document.createElement('p')
@@ -254,7 +259,7 @@ async function eventListener() {
   const creditElm = await createCreditsBanner()
   document.querySelector('.semesterChoice')!.appendChild(creditElm)
 
-  const { improveSelma } = await chrome.storage.local.get(['improveSelma'])
+  const improveSelma = await improveSelmaEnabledPromise
   if (!improveSelma) return
 
   // Inject css


### PR DESCRIPTION
### Pull Request

#### Description
This resolves an issue where the Selma improvement script won't activate when it gets injected after the `DOMContentLoaded` event. It also resolves a small layout issue with the credit banner.
See: https://stackoverflow.com/a/39993724

![image](https://github.com/user-attachments/assets/54522a58-7e47-45e2-8439-637efeae78f2)
![image](https://github.com/user-attachments/assets/a68c5e44-0d16-421c-bf4f-dba3cc042f65)


#### Type of change
- [x] Bug fix (non-breaking change which fixes a bug)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that might cause existing functionality to not work as expected)

#### Further info
- [ ] This change requires a documentation update
- [x] I updated the documentation accordingly, if required
- [x] I commented my code where its useful

#### Testing
We have 1500+ Users. Please test your changes thoroughly.
- [x] Tested my changes on Firefox
- [x] Tested my changes on Chromium-Based-Browsers
- [x] Successfully run `npm run test` locally

